### PR TITLE
Switch spots

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,10 @@
         ],
         "no-console": [
           0
+        ],
+        "curly": [
+          "error",
+          "multi-line"
         ]
     },
     "env": {

--- a/controllers/Results.js
+++ b/controllers/Results.js
@@ -9,11 +9,10 @@ function ResultsController() {
     .then(() => {
       const { id } = req.session.currentPerformance;
 
-      res.json({ message: 'success!' });
+      res.json({ success: true });
       Result.checkAllDoneForPerformance(id)
       .then(done => {
         if (done) {
-          console.log('Switching spots for performance id', id);
           Result.switchSpotsForPerformance(id);
         }
       })
@@ -21,7 +20,7 @@ function ResultsController() {
     })
     .catch((err) => {
       console.error(err);
-      res.json({ err });
+      res.json({ success: false });
     });
   };
 

--- a/controllers/Results.js
+++ b/controllers/Results.js
@@ -6,7 +6,19 @@ function ResultsController() {
     const { ids } = req.body;
 
     Result.approve(ids)
-    .then(() => res.json({ message: 'success!' }))
+    .then(() => {
+      const { id } = req.session.currentPerformance;
+
+      res.json({ message: 'success!' });
+      Result.checkAllDoneForPerformance(id)
+      .then(done => {
+        if (done) {
+          console.log('Switching spots for performance id', id);
+          Result.switchSpotsForPerformance(id);
+        }
+      })
+      .catch(err => console.error(err));
+    })
     .catch((err) => {
       console.error(err);
       res.json({ err });

--- a/db/queries/results-for-performance-query.sql
+++ b/db/queries/results-for-performance-query.sql
@@ -1,11 +1,12 @@
 SELECT t1.name AS nameOne, t2.name AS nameTwo, t1.spotId AS spotId, t1.id AS resultsId, t1.nameNumber AS nameNumberOne,
-       t2.nameNumber AS nameNumberTwo, t1.comments AS firstComments, t2.comments AS secondComments, t1.winnerId
+       t2.nameNumber AS nameNumberTwo, t1.comments AS firstComments, t2.comments AS secondComments, t1.winnerId,
+       t1.alternate AS userOneAlternate, t2.alternate AS userTwoAlternate
 FROM
-  (SELECT u1.name, r1.id, r1.spotId, u1.nameNumber, r1.firstComments AS comments, r1.winnerId, r1.pending
+  (SELECT u1.name, r1.id, r1.spotId, u1.nameNumber, r1.firstComments AS comments, r1.winnerId, r1.pending, u1.alternate
    FROM results AS r1, users AS u1
    WHERE r1.firstNameNumber = u1.nameNumber AND r1.performanceId = $1) t1
 LEFT JOIN
-  (SELECT u2.name, r2.id, u2.nameNumber, r2.secondComments AS comments
+  (SELECT u2.name, r2.id, u2.nameNumber, r2.secondComments AS comments, u2.alternate
    FROM results AS r2, users AS u2
    WHERE r2.secondNameNumber = u2.nameNumber) t2
 ON

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -159,9 +159,9 @@ BEGIN
   UPDATE spots SET challengedCount = challengedCount + 1 WHERE id = sId;
   UPDATE users SET eligible = FALSE WHERE nameNumber = uId;
 
-	message:= '';
+  message:= '';
 
-	RETURN message;
+  RETURN message;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -170,13 +170,13 @@ CREATE OR REPLACE FUNCTION get_user_result_comments(idOne varchar(256), comments
 RETURNS text AS $$
 DECLARE comments text;
 BEGIN
-	IF id = idOne THEN
-		comments := commentsOne;
-	ELSE
-		comments := commentsTwo;
-	END IF;
+  IF id = idOne THEN
+    comments := commentsOne;
+  ELSE
+    comments := commentsTwo;
+  END IF;
 
-	RETURN comments;
+  RETURN comments;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -184,29 +184,29 @@ CREATE OR REPLACE FUNCTION get_other_user_id(idCompare varchar(256), idOne varch
 RETURNS varchar(256) AS $$
 DECLARE id varchar(256);
 BEGIN
-	IF id = idOne THEN
-		id := idOne;
-	ELSE
-		id := idTwo;
-	END IF;
+  IF id = idOne THEN
+    id := idOne;
+  ELSE
+    id := idTwo;
+  END IF;
 
-	RETURN id;
+  RETURN id;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION created_stamp()
 RETURNS TRIGGER AS $$
 BEGIN
-	NEW.created_at = now();
-	RETURN NEW;
+  NEW.created_at = now();
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION modified_stamp()
 RETURNS TRIGGER AS $$
 BEGIN
-	NEW.modified_at = now();
-	RETURN NEW;
+  NEW.modified_at = now();
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -259,9 +259,9 @@ CREATE TABLE users (
   instrument instrument,
   part part,
   eligible boolean NOT NULL DEFAULT FALSE,
-	squadLeader boolean NOT NULL DEFAULT FALSE,
-	admin boolean NOT NULL DEFAULT FALSE,
-	alternate boolean NOT NULL DEFAULT FALSE,
+  squadLeader boolean NOT NULL DEFAULT FALSE,
+  admin boolean NOT NULL DEFAULT FALSE,
+  alternate boolean NOT NULL DEFAULT FALSE,
   created_at timestamp NOT NULL,
   modified_at timestamp NOT NULL
 );
@@ -277,7 +277,7 @@ FOR EACH ROW EXECUTE PROCEDURE modified_stamp();
 ----------------------------------------
 CREATE TABLE performances (
   id serial PRIMARY KEY,
-	name varchar(256) NOT NULL,
+  name varchar(256) NOT NULL,
   performDate timestamp NOT NULL,
   current boolean NOT NULL DEFAULT FALSE,
   openAt timestamp NOT NULL,
@@ -316,13 +316,13 @@ FOR EACH ROW EXECUTE PROCEDURE modified_stamp();
 CREATE TABLE results (
   id serial PRIMARY KEY,
   performanceId integer references performances(id) NOT NULL,
-	spotId varchar(3) references spots(id) NOT NULL,
+  spotId varchar(3) references spots(id) NOT NULL,
   firstNameNumber varchar(256) references users(nameNumber) NOT NULL,
-	secondNameNumber varchar(256) references users(nameNumber),
+  secondNameNumber varchar(256) references users(nameNumber),
   firstComments text NOT NULL DEFAULT '',
-	secondComments text NOT NULL DEFAULT '',
-	winnerId varchar(256) references users(nameNumber),
-	pending boolean NOT NULL DEFAULT false,
+  secondComments text NOT NULL DEFAULT '',
+  winnerId varchar(256) references users(nameNumber),
+  pending boolean NOT NULL DEFAULT false,
   needsApproval boolean NOT NULL DEFAULT true,
   created_at timestamp NOT NULL,
   modified_at timestamp NOT NULL

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -94,7 +94,7 @@ BEGIN
       END IF;
     END IF;
 
-    -- If two regulars were involved in the challenge
+    -- If two alternates were involved in the challenge
     IF (userOneAlternate AND userTwoAlternate) THEN
       IF userOne = winner THEN
         -- The person who originally had the open spot gets the loser's spot

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -138,16 +138,7 @@ BEGIN
   INSERT INTO challenges (userNameNumber, performanceId, spotId) VALUES (uId, pId, sId);
   UPDATE spots SET challengedCount = challengedCount + 1 WHERE id = sId;
   UPDATE users SET eligible = FALSE WHERE nameNumber = uId;
-  -- If the spot is fully challenged, we're going to add to the results table
-  -- There are two ways we could grab the other user. If they're also challenging the spot
-  -- or if the spot isn't open, we need the current user associated with the spot
-  IF (spotOpen AND cCount + 1 = 2) THEN
-    INSERT INTO results (performanceId, spotId, firstNameNumber, secondNameNumber, pending)
-    VALUES (pId, sId, (SELECT userNameNumber FROM challenges WHERE performanceId = pId AND spotId = sId), uId, TRUE);
-  ELSIF (NOT spotOpen AND cCount + 1 = 1) THEN
-    INSERT INTO results (performanceId, spotId, firstNameNumber, secondNameNumber, pending, needsApproval)
-    VALUES (pId, sId, uId, (SELECT nameNumber FROM users WHERE spotId = sId), TRUE, FALSE);
-  END IF;
+
 	message:= '';
 
 	RETURN message;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,6 +34,76 @@ BEGIN
 
   UPDATE performances SET current = FALSE WHERE id <> performanceId;
   UPDATE performances SET current = TRUE WHERE id = performanceId;
+
+/*
+  This function assumes that the array of resultIds has been sorted in a special order
+    - Regular vs Alternate
+    - Alternate vs Alternate
+    - Regular vs Regular
+  We're not going to worry about results where only one person is involved
+*/
+DROP FUNCTION IF EXISTS switch_spots_based_on_results(resultIds int[]);
+CREATE OR REPLACE FUNCTION switch_spots_based_on_results(resultIds int[])
+RETURNS VOID AS $$
+DECLARE userOne varchar(256); userTwo varchar(256); winner varchar(256); spotOne char(3); spotTwo char(3);
+winnerSpot char(3); id int; userOneAlternate boolean; userTwoAlternate boolean; spotOpen boolean;
+BEGIN
+
+  FOREACH id IN ARRAY resultIds
+  LOOP
+    SELECT firstNameNumber, secondNameNumber, winnerId, spotId
+    INTO userOne, userTwo, winner, winnerSpot
+    FROM results
+    WHERE result.id = id;
+
+    SELECT spotId, alternate INTO spotOne, userOneAlternate FROM users WHERE nameNumber = userOne;
+    SELECT spotId, alternate INTO spotTwo, userTwoAlternate FROM users WHERE nameNumber = userTwo;
+    SELECT open INTO spotOpen FROM spots WHERE id = spotId;
+
+    -- If it's an alternate vs regular for a non open spot, easy peasy :D
+    IF (userOneAlternate AND NOT userTwoAlternate AND NOT spotOpen) OR
+       (NOT userOneAlternate AND userTwoAlternate AND NOT spotOpen)
+    THEN
+      -- If the userOne won, but wasn't already in the spot won
+      IF userOne = winner AND spotOne <> winnerSpot THEN
+        UPDATE users SET spotId = winnerSpot WHERE nameNumber = userOne;
+        UPDATE users SET spotId = spotOne WHERE nameNumber = userTwo;
+      ELSIF winner = userTwo AND spotTwo <> winnerSpot THEN
+        UPDATE users SET spotId = winnerSpot WHERE nameNumber = userTwo;
+        UPDATE users SET spotId = spotTwo WHERE nameNumber = userOne;
+      END IF;
+    END IF;
+
+    -- If two regulars were involved in the challenge
+    IF (userOneAlternate AND userTwoAlternate) THEN
+      IF userOne = winner THEN
+        -- The person who originally had the open spot gets the loser's spot
+        UPDATE users SET spotId = spotTwo WHERE spotId = winnerSpot;
+        UPDATE users SET spotId = winnerSpot WHERE nameNumber = userOne;
+      ELSE
+        -- The person who originally had the open spot gets the loser's spot
+        UPDATE users SET spotId = spotOne WHERE spotId = winnerSpot;
+        UPDATE users SET spotId = winnerSpot WHERE nameNumber = userTwo;
+      END IF;
+    END IF;
+
+    -- If two regulars were involved in the challenge
+    IF (NOT userOneAlternate AND NOT userTwoAlternate) THEN
+      IF userOne = winner AND spotOne <> winnerSpot THEN
+        UPDATE users SET spotId = winnerSpot WHERE nameNumber = userOne;
+        UPDATE users SET spotId = spotOne WHERE nameNumber = userTwo;
+      ELSIF userTwo = winner AND spotTwo <> winnerSpot THEN
+        UPDATE users SET spotId = winnerSpot WHERE nameNumber = userTwo;
+        UPDATE users SET spotId = spotTwo WHERE nameNumber = userOne;
+      END IF;
+    END IF;
+
+  END LOOP;
+
+  -- Set all things back to normal
+  UPDATE spots SET challengedCount = 0, open = FALSE;
+  UPDATE users SET eligible = TRUE WHERE alternate;
+  UPDATE users SET eligible = FALSE WHERE NOT alternate;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -237,7 +307,7 @@ CREATE TABLE results (
   performanceId integer references performances(id) NOT NULL,
 	spotId varchar(3) references spots(id) NOT NULL,
   firstNameNumber varchar(256) references users(nameNumber) NOT NULL,
-	secondNameNumber varchar(256) references users(nameNumber) NOT NULL,
+	secondNameNumber varchar(256) references users(nameNumber),
   firstComments text NOT NULL DEFAULT '',
 	secondComments text NOT NULL DEFAULT '',
 	winnerId varchar(256) references users(nameNumber),

--- a/models/Result.js
+++ b/models/Result.js
@@ -230,7 +230,10 @@ module.exports = class Results {
       });
     });
 
-    resultsQuery.on('error', err => console.error(err));
+    resultsQuery.on('error', err => {
+      console.error(err);
+      client.end();
+    });
   }
 
   update(attributes) {


### PR DESCRIPTION
### In This PR
--------------------
- [ ] When a result is approved, the results controller checks if all results have been approved

If all results for the current performance are approved, the spots are switched. We have to do a special sorting so spots don't get messed up. The sorting is
- Regular vs Alternate
- Alternate vs Alternate
- Regular vs Regular

__Results with only one participant are done separately__

This has been tested against the current mock data with some additional results to add complexity.
This process runs under the assumption that the last result is approved during the time frame for the performance