### PR TITLE
Manage users

### DIFF
--- a/models/Manage.js
+++ b/models/Manage.js
@@ -42,6 +42,17 @@ class Manage {
     return db.query(sql, [performanceId], instanceFromRowManage);
   }
 
+  static findAllForUser(nameNumber) {
+    const sql = `
+      SELECT m.id AS id, p.name AS performanceName, m.usernamenumber, m.reason, m.spotid, m.voluntary
+      FROM manage AS m JOIN performances AS p on m.performanceid = p.id
+      WHERE m.usernamenumber = $1
+      ORDER BY id DESC
+    `;
+
+    return db.query(sql, [nameNumber], instanceFromRowPerformance);
+  }
+
   get id() {
     return this._id;
   }
@@ -70,7 +81,29 @@ class Manage {
     return this._voluntary;
   }
 
+  toJSON() {
+    return {
+      id: this._id,
+      performanceId: this._performanceId,
+      userName: this._userName,
+      userNameNumber: this._userNameNumber,
+      reason: this._reason,
+      spotId: this._spotId,
+      voluntary: this._voluntary
+    };
+  }
 }
+
+const instanceFromRowPerformance = ({ id, performancename, usernamenumber, reason, voluntary, spotid }) => (
+  {
+    id,
+    performanceName: performancename,
+    userNameNumber: usernamenumber,
+    reason,
+    spotId: spotid,
+    voluntary
+  }
+);
 
 const instanceFromRowManage = ({ id, performanceid, name, namenumber, reason, spotid, voluntary }) =>
   new Manage(id, performanceid, name, namenumber, reason, spotid, voluntary);

--- a/models/Spot.js
+++ b/models/Spot.js
@@ -2,7 +2,7 @@ const { db } = require('../utils');
 
 const attributes = ['id', 'open', 'challengedCount'];
 
-module.exports = class Spot {
+class Spot {
 
   constructor(id, open, challengedCount) {
     this._id = id;
@@ -28,6 +28,16 @@ module.exports = class Spot {
     return db.query(sql, [id]);
   }
 
+  static findByOwnerNameNumber(nameNumber) {
+    const sql = `
+      SELECT s.challengedcount, s.id, s.open
+      FROM spots AS s JOIN users AS u ON u.spotid = s.id
+      WHERE u.namenumber = $1
+    `;
+
+    return db.query(sql, [nameNumber], instanceFromDBRow);
+  }
+
   // true is open, false is closed
   static setOpenClose(spotId, open) {
     const sql = 'UPDATE spots SET open = $1 WHERE id = $2';
@@ -46,4 +56,17 @@ module.exports = class Spot {
   get open() {
     return this._open;
   }
-};
+
+  toJSON() {
+    return {
+      challengedCount: this._challengedCount,
+      id: this._id,
+      open: this._open
+    };
+  }
+}
+
+const instanceFromDBRow = ({ challengedcount, id, open }) =>
+  new Spot(id, open, challengedcount);
+
+module.exports = Spot;

--- a/public/components/challenge.jsx
+++ b/public/components/challenge.jsx
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react';
+
+const Challenge = ({ owner, performanceName, spotId }) => (
+  <h3 className="Challenge">
+    {owner ? 'You\'re currently signed up to challenged' : 'Challenged'} {spotId} for {performanceName}
+  </h3>
+);
+
+Challenge.propTypes = {
+  owner: PropTypes.bool.isRequired,
+  performanceName: PropTypes.string.isRequired,
+  spotId: PropTypes.string.isRequired
+};
+
+export default Challenge;

--- a/public/components/manage-action.jsx
+++ b/public/components/manage-action.jsx
@@ -1,0 +1,16 @@
+import React, { PropTypes } from 'react';
+
+const ManageAction = ({ performanceName, reason, spotId, voluntary }) => (
+  <h4 className="ManageAction">
+    - For the {performanceName}, {voluntary ? `${spotId} was opened` : `an admin opened ${spotId}`} because {reason}
+  </h4>
+);
+
+ManageAction.propTypes = {
+  performanceName: PropTypes.string.isRequired,
+  reason: PropTypes.string.isRequired,
+  spotId: PropTypes.string.isRequired,
+  voluntary: PropTypes.bool.isRequired
+};
+
+export default ManageAction;

--- a/public/components/manage-user-spot.jsx
+++ b/public/components/manage-user-spot.jsx
@@ -1,0 +1,109 @@
+import React, { Component, PropTypes } from 'react';
+
+import './manage-user-spot.scss';
+
+class ManageUser extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      valid: true
+    };
+    this.handleManage = this.handleManage.bind(this);
+  }
+
+  handleManage() {
+    const [checkedRefKey] = Object.keys(this.refs).filter((key) => this.refs[key].checked);
+
+    if (!this.props.spotOpen) {
+      let reason = '';
+      let voluntary = false;
+
+      switch (checkedRefKey) {
+      case 'FailedMusicCheck':
+        reason = 'Failed Music Check';
+        break;
+      case 'Voluntary':
+        reason = 'Voluntarily Opened Spot';
+        voluntary = true;
+        break;
+      default:
+        reason = this.refs.reason.value;
+        break;
+      }
+
+      if (reason === '') {
+        this.setState({
+          valid: false
+        });
+      } else {
+        this.props.onManage(this.props.spotId, reason, voluntary, true);
+      }
+    } else {
+      this.props.onManage(this.props.spotId, 'Closed Spot', false, false);
+    }
+  }
+
+  render() {
+    const { spotOpen } = this.props;
+    const { valid } = this.state;
+
+    if (spotOpen) {
+      return (
+        <div className="ManageUserSpot">
+          Spot is Open
+          <button className="ManageUserSpot-button" onClick={this.handleManage}>Close Spot</button>
+        </div>
+      );
+    } else {
+      return (
+        <div className="ManageUserSpot">
+          {!valid && <p>**Please enter a reason for opening the spot**</p>}
+          Spot is closed
+          <button className="ManageUserSpot-button" onClick={this.handleManage}>Open Spot</button>
+          <p>For What Reason?</p>
+          <p>
+            <span>Failed Music Check </span>
+            <input
+              className="IndividualManage-failed"
+              defaultChecked
+              name="openSpotOptions"
+              ref="FailedMusicCheck"
+              type="radio"
+              value="Failed Music Check"
+            />
+          </p>
+          <p>
+            <span>Voluntarily Opened Spot </span>
+            <input
+              className="IndividualManage-failed"
+              name="openSpotOptions"
+              ref="Voluntary"
+              type="radio"
+              value="Voluntary"
+            />
+          </p>
+          <p>
+            <span>Other </span>
+            <input
+              className="IndividualManage-failed"
+              name="openSpotOptions"
+              ref="Other"
+              type="radio"
+              value="Other"
+            />
+            <input className="IndividualManage-reason" placeholder="Discipline reason" ref="reason" />
+          </p>
+        </div>
+      );
+    }
+  }
+}
+
+ManageUser.propTypes = {
+  onManage: PropTypes.func.isRequired,
+  spotId: PropTypes.string.isRequired,
+  spotOpen: PropTypes.bool.isRequired
+};
+
+export default ManageUser;

--- a/public/components/manage-user-spot.scss
+++ b/public/components/manage-user-spot.scss
@@ -1,0 +1,11 @@
+@import '../style.scss';
+
+.ManageUserSpot {
+  font-size: 16px;
+}
+
+.ManageUserSpot-button {
+  @extend .ChallengesButton;
+
+  margin-left: 10px;
+}

--- a/public/components/navbar.jsx
+++ b/public/components/navbar.jsx
@@ -5,6 +5,7 @@ import './navbar.scss';
 import ChallengesDropdown from './challenges-dropdown';
 import PerformancesDropdown from './performances-dropdown';
 import ResultsDropdown from './results-dropdown';
+import UserManageDropdown from './user-manage-dropdown';
 
 const Navbar = ({ onLogout, user }) => (
   <div className="Navbar" id="MessageAppend">
@@ -20,6 +21,9 @@ const Navbar = ({ onLogout, user }) => (
       </div>
       <div className="Navbar-item">
         {user && (user.squadLeader || user.admin) && <ResultsDropdown user={user} />}
+      </div>
+      <div className="Navbar-item">
+        {user && user.admin && <UserManageDropdown />}
       </div>
     </div>
     {user &&

--- a/public/components/profile.jsx
+++ b/public/components/profile.jsx
@@ -4,6 +4,7 @@ import './profile.scss';
 import { api } from '../utils';
 import ChallengeWindow from './challenge-window';
 import Results from './results-for-user';
+import UserHeader from './user-header';
 
 const adminText = (
   <div>
@@ -39,19 +40,6 @@ const currentChallengeWrapper = (canChallenge, performanceName, spotId) => {
   return null;
 };
 
-const profileTitle = (name, spotId, admin) => (
-  <div className="Profile-title">
-    <div className={admin ? 'Profile-title-admin' : 'Profile-title-spot'}>
-      <h1 className="Profile-title-text">
-        {spotId || 'Admin'}
-      </h1>
-    </div>
-    <h1 className="Profile-title-name">
-      {name}
-    </h1>
-  </div>
-);
-
 class Profile extends Component {
 
   constructor() {
@@ -82,7 +70,7 @@ class Profile extends Component {
 
     return (
       <div className="Profile">
-        {profileTitle(name, spotId, admin)}
+        <UserHeader admin={admin} name={name} spotId={spotId} />
         {performance && <ChallengeWindow {...performance} />}
         {currentChallengeWrapper(canChallenge, challenge && challenge.performanceName, challenge && challenge.spotId)}
         <Results results={results} />

--- a/public/components/user-header.jsx
+++ b/public/components/user-header.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react';
+
+import './user-header.scss';
+
+const UserHeader = ({ name, spotId, admin }) => (
+  <div className="UserHeader">
+    <div className={admin ? 'UserHeader-admin' : 'UserHeader-spot'}>
+      <h1 className="UserHeader-text">
+        {admin ? 'Admin' : spotId}
+      </h1>
+    </div>
+    <h1 className="UserHeader-name">
+      {name}
+    </h1>
+  </div>
+);
+
+UserHeader.propTypes = {
+  admin: PropTypes.bool.isRequired,
+  name: PropTypes.string.isRequired,
+  spotId: PropTypes.string
+};
+
+export default UserHeader;

--- a/public/components/user-header.scss
+++ b/public/components/user-header.scss
@@ -1,0 +1,34 @@
+@import '../style.scss';
+
+.UserHeader {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  padding-top: 10px;
+}
+
+.UserHeader-admin {
+  color: $Challenges-red;
+}
+
+.UserHeader-spot {
+  background: $Challenges-red;
+  border-radius: 50%;
+  color: #fff;
+  display: flex;
+  font-size: 30px;
+  height: 100px;
+  justify-content: center;
+  text-align: center;
+  vertical-align: middle;
+  width: 100px;
+}
+
+.UserHeader-text {
+  align-self: center;
+}
+
+.UserHeader-name {
+  align-self: center;
+  padding-left: 10px;
+}

--- a/public/components/user-manage-dropdown.jsx
+++ b/public/components/user-manage-dropdown.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import Dropdown from './dropdown';
+
+export default function UserManageDropdown() {
+  const links = [
+    {
+      location: '/users',
+      name: 'Roster'
+    },
+    {
+      location: '/users/manage',
+      name: 'Search'
+    }
+  ];
+
+  return <Dropdown name="Users" links={links} />;
+}

--- a/public/components/user-manage-dropdown.jsx
+++ b/public/components/user-manage-dropdown.jsx
@@ -9,7 +9,7 @@ export default function UserManageDropdown() {
       name: 'Roster'
     },
     {
-      location: '/users/manage',
+      location: '/users/search',
       name: 'Search'
     }
   ];

--- a/public/components/user-search.jsx
+++ b/public/components/user-search.jsx
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router';
+
+import './user-search.scss';
+import { api } from '../utils';
+
+export default class UserSearch extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      searchResults: [],
+      query: ''
+    };
+    this.handleSearch = this.handleSearch.bind(this);
+  }
+
+  handleSearch({ target }) {
+    this.setState({
+      query: target.value
+    });
+
+    if (target.value.length > 2) {
+      api.get(`/users/search?q=${target.value}`)
+      .then((users) => {
+        this.setState({
+          ...this.state,
+          searchResults: users
+        });
+      });
+    }
+  }
+
+  render() {
+    return (
+      <div className="UserSearch">
+        <input
+          autoFocus
+          className="UserSearch-search"
+          onChange={this.handleSearch}
+          placeholder="Search For User"
+          value={this.state.query}
+        />
+        <div className="UserSearch-results">
+          <ul className="UserSearch-results-list">
+            {this.state.searchResults.map(({ name, nameNumber }) =>
+              <li className="UserSearch-result" key={nameNumber}>
+                <Link to={`/users/profile/${nameNumber}`}>Manage {name}</Link>
+              </li>
+            )}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}

--- a/public/components/user-search.scss
+++ b/public/components/user-search.scss
@@ -1,0 +1,44 @@
+.UserSearch {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding-top: 15px;
+  width: 80%;
+}
+
+.UserSearch-search {
+  font-size: 20px;
+  width: 100%;
+}
+
+.UserSearch-results {
+  flex-basis: 0px;
+  flex-grow: 4;
+  padding-top: 5px;
+  width: 100;
+}
+
+.UserSearch-results-list {
+  margin-bottom: 20px;
+  padding-left: 0px;
+}
+
+.UserSearch-result {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+  margin-bottom: -1px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+}
+
+.UserSearch-result:first-child {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.UserSearch-result:last-child {
+  margin-bottom: 0;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+}

--- a/public/components/user.jsx
+++ b/public/components/user.jsx
@@ -1,0 +1,98 @@
+import React, { Component, PropTypes } from 'react';
+
+import { api } from '../utils';
+import Challenge from './challenge';
+import ManageAction from './manage-action';
+import ManageUserSpot from './manage-user-spot';
+import ResultsForUser from './results-for-user';
+import UserHeader from './user-header';
+
+const getProfileInfo = (nameNumber) =>
+  api.get(`/users/profile?nameNumber=${nameNumber}`);
+
+class User extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      challenges: null,
+      loading: true,
+      manages: null,
+      performance: null,
+      results: null,
+      spot: null,
+      user: null
+    };
+    this.handleManage = this.handleManage.bind(this);
+  }
+
+  componentDidMount() {
+    const { nameNumber } = this.props.params;
+
+    getProfileInfo(nameNumber)
+    .then((profileInfo) => {
+      this.setState({
+        ...profileInfo,
+        loading: false
+      });
+    });
+  }
+
+  handleManage(spotId, reason, voluntary, spotOpen) {
+    api.post('/users/manage', {
+      performanceId: this.state.performance.id,
+      nameNumber: this.state.user.nameNumber,
+      reason,
+      spotId,
+      spotOpen,
+      voluntary
+    }).then(() => {
+      getProfileInfo(this.state.user.nameNumber)
+      .then((profileInfo) => {
+        this.setState({
+          ...profileInfo
+        });
+      });
+    });
+  }
+
+  render() {
+    const { challenges, loading, manages, performance, results, spot, user } = this.state;
+
+    if (loading) {
+      return <div>Loading...</div>;
+    }
+
+    return (
+      <div className="User">
+        <UserHeader admin={user.admin} name={user.name} spotId={spot.id} />
+        <h2>Manage</h2>
+        {performance === null ?
+          <h2>There is no upcoming performance in the system, so no manage action can be made</h2> :
+            <ManageUserSpot onManage={this.handleManage} spotId={spot.id} spotOpen={spot.open} />
+        }
+        {manages.length > 0 ?
+          <div>
+            <h3>Previous Action Items</h3>
+            {manages.map(({ id, ...rest }) => <ManageAction key={id} {...rest} />)}
+          </div> :
+            <h3>Not previous actions have been made for this user</h3>
+        }
+        <hr />
+        <h2>Previous Challenges</h2>
+        {challenges.map(({ id, ...rest }) => <Challenge {...rest} key={id} owner={false} />)}
+        <hr />
+        <h2>Previous Results</h2>
+        <ResultsForUser results={results} />
+      </div>
+    );
+  }
+}
+
+User.propTypes = {
+  params: PropTypes.shape({
+    nameNumber: PropTypes.string.isRequired
+  })
+};
+
+export default User;

--- a/public/index.jsx
+++ b/public/index.jsx
@@ -15,10 +15,12 @@ import PastResults from './components/past-results';
 import Profile from './components/profile';
 import ResultsForApproval from './components/results-for-approval';
 import ResultsForEvaluation from './components/results-for-evaluation';
+import User from './components/user';
+import UserSearch from './components/user-search';
 
 const renderBasedOnAuth = (Component, pattern, props, user) => {
   if (auth.isAuthenticated() && auth.userCanAccess(pattern)) {
-    return <Component user={user} />;
+    return <Component {...props} user={user} />;
   } else if (auth.isAuthenticated()) {
     return <NotFound />;
   } else {
@@ -63,6 +65,8 @@ const App = () => (
             <MatchWhenAuthorized exactly pattern="/performances/new" component={CreatePerformance} />
             <MatchWhenAuthorized exactly pattern="/results" component={PastResults} />
             <MatchWhenAuthorized exactly pattern="/results/toApprove" component={ResultsForApproval} />
+            <MatchWhenAuthorized exactly pattern="/users/search" component={UserSearch} />
+            <MatchWhenAuthorized exactly pattern="/users/profile/:nameNumber" component={User} />
             <MatchWhenNotLoggedIn pattern="/login" component={Login} />
             <Miss component={NotFound} />
           </div>

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -32,7 +32,9 @@ router.put('/results/evaluate', ensureAdminOrSquadLeader, Results.evaluate);
 
 // Users Controller
 router.get('/profile', ensureAuthenticated, Users.profile);
-
+router.get('/users/search', ensureAdmin, Users.search);
+router.get('/users/profile', ensureAdmin, Users.userProfileForAdmin);
+router.post('/users/manage', ensureAdmin, Users.manage);
 
 
 //Challenges Controller
@@ -46,9 +48,6 @@ router.post('/performances/create', ensureAdmin, Performances.create);
 //Users Controller
 router.get('/users/manage', ensureAdmin, Users.showManage);
 router.get('/users/manage/:nameNumber', ensureAdmin, Users.showIndividualManage);
-router.get('/users/search', ensureAdmin, Users.search);
-router.post('/users/manage', ensureAdmin, Users.manage);
-router.post('/users/manage/close', ensureAdmin, Users.closeSpot);
 router.put('/users', ensureAdmin, Users.update);
 router.put('/users/password', Users.changePassword);
 


### PR DESCRIPTION
# In This PR

- Added User Manage Actions (opening and closing spots)

For that to happen, a few things needed to happen

- New Users Controller method for fetching user information on behalf of an admin
- Made `UsersController.manage` take value on whether or not to open spot, removing need for `.closeSpot`
- `Manage.findForUser` is easier than what was happening before along with Manage.toJSON
- `Spot.findOwnerByNameNumber` to get updated information about a spot belonging to a user
- Various React components to build the admin view for a user's profile

# TODO
- [x] Check on staging!