### PR TITLE
User challenge refactor

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -8,7 +8,7 @@ class Challenge < ApplicationRecord
   has_many :users, through: :user_challenges
   belongs_to :spot
   belongs_to :performance
-  belongs_to :winner, class_name: 'User', foreign_key: 'winner_id', optional: true
+  belongs_to :winner, class_name: 'User', foreign_key: 'winner_buck_id', optional: true
 
   # validations
   validates :performance, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Metrics/ClassLength
 class User < ApplicationRecord
+  self.primary_key = 'buck_id'
+
   scope :performers, -> { where(role: [:member, :squad_leader]) }
 
   # enums

--- a/db/migrate/20170224051154_add_challenges.rb
+++ b/db/migrate/20170224051154_add_challenges.rb
@@ -5,7 +5,7 @@ class AddChallenges < ActiveRecord::Migration[5.0]
       t.column :stage, :integer, default: 0
       t.belongs_to :spot
       t.belongs_to :performance
-      t.column :winner_id, :integer, foreign_key: true
+      t.column :winner_buck_id, :string, foreign_key: true
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20170504003831) do
     t.integer  "stage",          default: 0
     t.integer  "spot_id"
     t.integer  "performance_id"
-    t.integer  "winner_id"
+    t.string   "winner_buck_id"
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.index ["performance_id"], name: "index_challenges_on_performance_id", using: :btree

--- a/spec/factories/challenges.rb
+++ b/spec/factories/challenges.rb
@@ -1,18 +1,39 @@
 FactoryGirl.define do
   factory :challenge do
-    performance { Performance.first || FactoryGirl.create(:performance) }
-    spot { Spot.find_by(row: Spot.rows[:a], file: 1) || FactoryGirl.create(:spot) }
+    performance { FactoryGirl.create(:performance) }
+    after(:build) do |c|
+      c.user_challenges.each do |uc|
+        uc.spot = uc.user.spot
+      end
+    end
   end
 
   factory :open_spot_challenge, parent: :challenge do
     challenge_type :open_spot
+    spot { Spot.create(row: :a, file: 1) }
+    users { [FactoryGirl.create(:user, :spot_a13, :trumpet, :solo)] }
   end
 
   factory :normal_challenge, parent: :challenge do
     challenge_type :normal
+    spot { Spot.create(row: :a, file: 1) }
+    users {
+      [
+        FactoryGirl.create(:user, :spot_a13, :trumpet, :solo),
+        FactoryGirl.create(:user, :trumpet, :solo, spot: spot)
+      ]
+    }
   end
 
   factory :tri_challenge, parent: :challenge do
     challenge_type :tri
+    spot { FactoryGirl.create(:spot, row: :j, file: 8) }
+    users {
+      [
+        FactoryGirl.create(:user, :spot_j15, :percussion, :bass),
+        FactoryGirl.create(:user, :spot_j17, :percussion, :bass),
+        FactoryGirl.create(:user, :percussion, :bass, spot: spot)
+      ]
+    }
   end
 end

--- a/spec/models/challenge_spec.rb
+++ b/spec/models/challenge_spec.rb
@@ -12,32 +12,27 @@ describe Challenge, type: :model do
       subject { build(:normal_challenge) }
 
       it 'is invalid without 2 users' do
+        subject.users = [subject.users.first] # remove a user
         subject.valid?
         expect(subject.errors.full_messages)
           .to include('Users only two users are allowed in a normal challenge')
       end
 
       it 'is valid with 2 users' do
-        subject.users << build(:user)
-        subject.users << build(:user)
-
         subject.valid?
         expect(subject.errors.full_messages)
           .not_to include('Users only two users are allowed in a normal challenge')
       end
 
       it 'requires users in a challenge to have the same instrument and part' do
-        subject.users << build(:user, :trumpet, :solo)
-        subject.users << build(:user, :trumpet, :first)
-
+        subject.users = [build(:user, :trumpet, :solo), build(:user, :trumpet, :first)]
         subject.valid?
         expect(subject.errors.full_messages)
           .to include('Users must all have the same instrument and part')
       end
 
       it 'requires users in a challenge to not be admins or directors' do
-        subject.users << build(:admin_user)
-        subject.users << build(:user)
+        subject.users = [build(:admin_user), build(:user)]
 
         subject.valid?
         expect(subject.errors.full_messages)
@@ -59,14 +54,15 @@ describe Challenge, type: :model do
     subject { build(:open_spot_challenge) }
 
     it 'is invalid with no users' do
+      subject.users = []
+
       subject.valid?
       expect(subject.errors.full_messages)
         .to include('Users no more than two users are allowed in an open spot challenge')
     end
 
     it 'is valid with 2 users' do
-      subject.users << build(:user)
-      subject.users << build(:user)
+      subject.users = [build(:user), build(:user)]
 
       subject.valid?
       expect(subject.errors.full_messages)
@@ -78,15 +74,14 @@ describe Challenge, type: :model do
     subject { build(:tri_challenge) }
 
     it 'is invalid without 3 users' do
+      subject.users = []
       subject.valid?
       expect(subject.errors.full_messages)
         .to include('Users only three users are allowed in a tri challenge')
     end
 
     it 'is valid with 3 users' do
-      subject.users << build(:user)
-      subject.users << build(:user)
-      subject.users << build(:user)
+      subject.users = [build(:user), build(:user), build(:user)]
 
       subject.valid?
       expect(subject.errors.full_messages)
@@ -98,31 +93,26 @@ describe Challenge, type: :model do
     context 'when the challenge is normal' do
       subject { build(:normal_challenge) }
 
-      let(:user) { build(:user) }
-
       it 'is full with two users' do
-        subject.users = [user, user]
-
         expect(subject.full?).to be(true)
       end
 
       it 'is not full with less than two users' do
+        subject.users = []
         expect(subject.full?).to be(false)
       end
     end
 
     context 'when the challenge is open spot' do
       subject { build(:open_spot_challenge) }
-
-      let(:user) { build(:user) }
-
       it 'is full with two users' do
-        subject.users = [user, user]
+        subject.users = [build(:user), build(:user)]
 
         expect(subject.full?).to be(true)
       end
 
       it 'is not full with less than two users' do
+        subject.users = [build(:user)]
         expect(subject.full?).to be(false)
       end
     end
@@ -139,6 +129,7 @@ describe Challenge, type: :model do
       end
 
       it 'is not full with less than three users' do
+        subject.users = []
         expect(subject.full?).to be(false)
       end
     end

--- a/spec/models/user_challenge_spec.rb
+++ b/spec/models/user_challenge_spec.rb
@@ -1,27 +1,20 @@
 require 'rails_helper'
 
 describe UserChallenge, type: :model do
-  let(:performance) { create(:performance) }
-  let(:challengee) { create(:user, :trumpet, :solo, :spot_a2) }
-  let(:challenger) { create(:alternate_user, :trumpet, :solo, :spot_a13) }
-
-  describe '.can_user_remove_self_from_challenge?' do
+  let(:challenge) { create(:normal_challenge) }
+  describe '#can_user_remove_self_from_challenge?' do
     context 'when the challenge is normal' do
-      let(:challenge) { build(:normal_challenge, spot: challengee.spot, performance: performance) }
-
-      before do
-        challenge.users = [challengee, challenger]
-      end
-
       it 'lets the challenger leave the challenge' do
+        challenger = challenge.users.select(&:alternate?).first
         expect(
-          described_class.can_user_remove_self_from_challenge?(challenger, challenge, challenge.user_challenges[1])
+          described_class.can_user_remove_self_from_challenge?(challenger, challenge, challenger.user_challenges.first)
         ).to be(true)
       end
 
       it 'does not let the challengee leave the challenge' do
+        challengee = challenge.users.reject(&:alternate?).first
         expect(
-          described_class.can_user_remove_self_from_challenge?(challengee, challenge, challenge.user_challenges[0])
+          described_class.can_user_remove_self_from_challenge?(challengee, challenge, challengee.user_challenges.first)
         ).to be(false)
       end
     end


### PR DESCRIPTION
Update `Challenge` factory to actually create valid challenges

The problem was that the associated `user_challenges` were invalid because they didn't have an associated spot. That's fixed

Also fixed a bug where `challege.winner` returned nil because of an incorrectly named foreign key