### PR TITLE
Discipline Action Controller before action

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -16,8 +16,8 @@ const parseErrorMessage = (response) => {
   if (headersHelpers.isJSONResponse(response)) {
     return response.json()
     .then((thing) => {
-      if (!thing.error) return getMessageFromStatus(response.status);
-      return thing.error;
+      if ((thing.errors || []).length <= 0) return getMessageFromStatus(response.status);
+      return thing.errors.map(error => Object.values(error)).join('. ');
     })
     .catch(() => DEFAULT_ERROR_MESSAGE);
   } else {


### PR DESCRIPTION
Don't let a current discipline action get deleted if someone has already challenged the spot the action opened