### PR TITLE
Fixes 371

### DIFF
--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -118,7 +118,7 @@ class ChallengesController < ApplicationController
 
   def ensure_user_is_challenging_correct_instrument_and_part!
     spot = Spot.find_by(row: Spot.rows[params[:spot][:row].downcase], file: params[:spot][:file])
-    challengee = User.find_by spot: spot
+    challengee = User.find_by current_spot: spot
     return if challenger.instrument == challengee.instrument && challenger.part == challengee.part
     render(
       json: {

--- a/app/controllers/discipline_actions_controller.rb
+++ b/app/controllers/discipline_actions_controller.rb
@@ -40,7 +40,7 @@ class DisciplineActionsController < ApplicationController
   def ensure_spot_hasnt_been_challenged!
     da = DisciplineAction.find params[:id]
     user = da.user
-    user_spot = user.spot
+    user_spot = user.current_spot
     performance = da.performance
     challenges = Challenge.where(performance: performance, spot: user_spot)
     return if challenges.empty?

--- a/app/controllers/user_challenges_controller.rb
+++ b/app/controllers/user_challenges_controller.rb
@@ -9,7 +9,7 @@ class UserChallengesController < ApplicationController
 
   def create
     challenge = Challenge.find_by id: params[:challenge_id]
-    @user_challenge = UserChallenge.new(user: challenger, challenge: challenge, spot: challenger.spot)
+    @user_challenge = UserChallenge.new(user: challenger, challenge: challenge, spot: challenger.current_spot)
 
     if @user_challenge.save
       render 'user_challenges/show', status: 201

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   before_action :ensure_target_spot_exists!, only: [:switch_spot]
 
   def index
-    @users = User.performers.includes(:current_spot).sort_by(&:current_spot)
+    @users = User.performers.includes(:current_spot, :original_spot).sort_by(&:current_spot)
   end
 
   def show

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -23,7 +23,7 @@ class Challenge < ApplicationRecord
   validate :valid_needs_approval_state
 
   # scopes
-  scope :with_users_and_spots, -> { includes(user_challenges: { user: :current_spot }) }
+  scope :with_users_and_spots, -> { includes(user_challenges: { user: :original_spot }) }
   scope :done, -> { where(stage: :done) }
   scope :needs_comments, -> { where(stage: :needs_comments) }
   scope :viewable_by_user, lambda { |user|
@@ -32,7 +32,7 @@ class Challenge < ApplicationRecord
     elsif user.director?
       with_users_and_spots.where(users: { instrument: user.instrument })
     elsif user.squad_leader?
-      ids = with_users_and_spots.where(spots: { row: user.current_spot.row }).pluck(:id)
+      ids = with_users_and_spots.where(spots: { row: user.original_spot.row }).pluck(:id)
       with_users_and_spots.where(id: ids)
     else
       none

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -23,7 +23,7 @@ class Challenge < ApplicationRecord
   validate :valid_needs_approval_state
 
   # scopes
-  scope :with_users_and_spots, -> { includes(user_challenges: { user: :spot }) }
+  scope :with_users_and_spots, -> { includes(user_challenges: { user: :current_spot }) }
   scope :done, -> { where(stage: :done) }
   scope :needs_comments, -> { where(stage: :needs_comments) }
   scope :viewable_by_user, lambda { |user|
@@ -32,7 +32,7 @@ class Challenge < ApplicationRecord
     elsif user.director?
       with_users_and_spots.where(users: { instrument: user.instrument })
     elsif user.squad_leader?
-      ids = with_users_and_spots.where(spots: { row: user.spot.row }).pluck(:id)
+      ids = with_users_and_spots.where(spots: { row: user.current_spot.row }).pluck(:id)
       with_users_and_spots.where(id: ids)
     else
       none

--- a/app/models/challenge/list_builder.rb
+++ b/app/models/challenge/list_builder.rb
@@ -46,7 +46,7 @@ class Challenge
     end
 
     def discipline_action_to_list_row(da)
-      [da.user.spot.to_s, da.user.full_name, da.reason]
+      [da.user.current_spot.to_s, da.user.full_name, da.reason]
     end
 
     def challenge_list_to_rows(challenges)

--- a/app/models/challenge/spot_switcher.rb
+++ b/app/models/challenge/spot_switcher.rb
@@ -40,12 +40,12 @@ class Challenge
       user_challenges = challenge.user_challenges
       winner = user_challenges.select(&:first_place?).first.user
       loser = user_challenges.reject(&:first_place?).first.user
-      return if winner.spot == challenge.spot
+      return if winner.current_spot == challenge.spot
       User.transaction do
-        s = winner.spot
-        winner.update_attributes!(spot: nil)
-        loser.update_attributes!(spot: s)
-        winner.update_attributes!(spot: challenge.spot)
+        s = winner.current_spot
+        winner.update_attributes!(current_spot: nil)
+        loser.update_attributes!(current_spot: s)
+        winner.update_attributes!(current_spot: challenge.spot)
       end
     end
 
@@ -53,35 +53,35 @@ class Challenge
     def switch_for_open_spot_challenge(challenge)
       user_challenges = challenge.user_challenges
       winner = user_challenges.select(&:first_place?).first.user
-      user_who_had_spot = User.find_by(spot: challenge.spot)
+      user_who_had_spot = User.find_by(current_spot: challenge.spot)
       User.transaction do
-        winner_spot = winner.spot
-        user_who_had_spot.update_attributes!(spot: nil)
-        winner.update_attributes!(spot: challenge.spot)
-        user_who_had_spot.update_attributes!(spot: winner_spot)
+        winner_spot = winner.current_spot
+        user_who_had_spot.update_attributes!(current_spot: nil)
+        winner.update_attributes!(current_spot: challenge.spot)
+        user_who_had_spot.update_attributes!(current_spot: winner_spot)
       end
     end
 
     # The winner gets the lowest spot numerically
     # 2nd place gets the middle number
     # 3rd place gets the highest
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/LineLength
     def switch_for_tri_challenge(challenge)
       user_challenges = challenge.user_challenges
       first_place = user_challenges.select(&:first_place?).first.user
       second_place = user_challenges.select(&:second_place?).first.user
       last_place = user_challenges.select(&:third_place?).first.user
-      return if first_place.spot.file < second_place.spot.file && second_place.spot.file < last_place.spot.file
-      spots = [first_place.spot, second_place.spot, last_place.spot].sort { |a, b| a.file - b.file }
+      return if first_place.current_spot.file < second_place.current_spot.file && second_place.current_spot.file < last_place.current_spot.file
+      spots = [first_place.current_spot, second_place.current_spot, last_place.current_spot].sort { |a, b| a.file - b.file }
 
-      first_place.update_attributes!(spot: nil)
-      second_place.update_attributes!(spot: nil)
-      last_place.update_attributes!(spot: nil)
+      first_place.update_attributes!(current_spot: nil)
+      second_place.update_attributes!(current_spot: nil)
+      last_place.update_attributes!(current_spot: nil)
 
-      first_place.update_attributes!(spot: spots.first)
-      second_place.update_attributes!(spot: spots[1])
-      last_place.update_attributes!(spot: spots.last)
+      first_place.update_attributes!(current_spot: spots.first)
+      second_place.update_attributes!(current_spot: spots[1])
+      last_place.update_attributes!(current_spot: spots.last)
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/LineLength
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -5,6 +5,7 @@ class Spot < ApplicationRecord
   # associations
   has_many :challenges
   has_one :current_user, class_name: 'User', foreign_key: 'current_spot_id'
+  has_one :original_user, class_name: 'User', foreign_key: 'original_spot_id'
 
   # validations
   validates :row, presence: true

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -4,7 +4,7 @@ class Spot < ApplicationRecord
 
   # associations
   has_many :challenges
-  has_one :user
+  has_one :current_user, class_name: 'User', foreign_key: 'current_spot_id'
 
   # validations
   validates :row, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
 
   # associations
   belongs_to :current_spot, class_name: 'Spot', foreign_key: :current_spot_id, optional: true
+  belongs_to :original_spot, class_name: 'Spot', foreign_key: :original_spot_id, optional: true
   has_many :user_challenges, foreign_key: 'user_buck_id'
   has_many :challenges, through: :user_challenges
   has_many :discipline_actions, foreign_key: 'user_buck_id'
@@ -33,6 +34,7 @@ class User < ApplicationRecord
   validates :part, presence: true
   validates :role, presence: true
   validates :current_spot_id, uniqueness: { allow_blank: true }
+  validates :original_spot_id, uniqueness: { allow_blank: true }
 
   validate :performing_member_has_spot, on: :create
   validate :admin_does_not_have_spot
@@ -105,6 +107,7 @@ class User < ApplicationRecord
     return if admin? || director?
     return unless current_spot.nil?
     errors.add(:current_spot, 'can\'t be blank')
+    errors.add(:original_spot, 'can\'t be blank')
   end
 
   def admin_does_not_have_spot

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   enum role: [:admin, :director, :member, :squad_leader]
 
   # associations
-  belongs_to :spot, optional: true
+  belongs_to :current_spot, class_name: 'Spot', foreign_key: :current_spot_id, optional: true
   has_many :user_challenges, foreign_key: 'user_buck_id'
   has_many :challenges, through: :user_challenges
   has_many :discipline_actions, foreign_key: 'user_buck_id'
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   validates :instrument, presence: true
   validates :part, presence: true
   validates :role, presence: true
-  validates :spot_id, uniqueness: { allow_blank: true }
+  validates :current_spot_id, uniqueness: { allow_blank: true }
 
   validate :performing_member_has_spot, on: :create
   validate :admin_does_not_have_spot
@@ -60,7 +60,7 @@ class User < ApplicationRecord
     payload[:buckId] = buck_id
     payload[:firstName] = first_name
     payload[:lastName] = last_name
-    payload[:spot] = spot && { row: spot.row.upcase, file: spot.file }
+    payload[:currentSpot] = current_spot && { row: current_spot.row.upcase, file: current_spot.file }
     payload[:instrument] = instrument&.capitalize
     payload[:part] = part&.capitalize
     payload[:role] = role.camelize
@@ -71,7 +71,7 @@ class User < ApplicationRecord
   # rubocop:enable Metrics/MethodLength
 
   def alternate?
-    spot.file > 12
+    current_spot.file > 12
   end
 
   def can_challenge_for_performance?(performance)
@@ -103,27 +103,27 @@ class User < ApplicationRecord
 
   def performing_member_has_spot
     return if admin? || director?
-    return unless spot.nil?
-    errors.add(:spot, 'can\'t be blank')
+    return unless current_spot.nil?
+    errors.add(:current_spot, 'can\'t be blank')
   end
 
   def admin_does_not_have_spot
     return if !admin? && !director?
-    return if spot.nil?
+    return if current_spot.nil?
     errors.add(:role, 'admin or director can\'t have a spot')
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/LineLength
   def valid_instrument_part_for_user
     return if admin? || director?
     return if instrument.nil? || part.nil?
-    return if spot.nil?
-    return if Spot.valid_instrument_part_for_row(Spot.rows[spot.row], User.instruments[instrument], User.parts[part])
-    errors.add(:spot, "row #{spot.row}, can't be a #{part} #{instrument}")
+    return if current_spot.nil?
+    return if Spot.valid_instrument_part_for_row(Spot.rows[current_spot.row], User.instruments[instrument], User.parts[part])
+    errors.add(:current_spot, "row #{current_spot.row}, can't be a #{part} #{instrument}")
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/LineLength
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def valid_instrument_part_for_admin
     return unless admin? || director?
     return if instrument_any? || any_part?

--- a/app/models/user/loader.rb
+++ b/app/models/user/loader.rb
@@ -71,7 +71,7 @@ class User
     def create_user_from_row(row, spot)
       password = SecureRandom.base64(15)
       digest = BCrypt::Password.create(password)
-      user_attrs = user_attrs_from_row(row).merge!(password_digest: digest, current_spot: spot)
+      user_attrs = user_attrs_from_row(row).merge!(password_digest: digest, current_spot: spot, original_spot: spot)
       user = User.new(user_attrs)
       return if user.admin? && User.exists?(buck_id: user.buck_id)
       user.save

--- a/app/models/user/loader.rb
+++ b/app/models/user/loader.rb
@@ -71,7 +71,7 @@ class User
     def create_user_from_row(row, spot)
       password = SecureRandom.base64(15)
       digest = BCrypt::Password.create(password)
-      user_attrs = user_attrs_from_row(row).merge!(password_digest: digest, spot: spot)
+      user_attrs = user_attrs_from_row(row).merge!(password_digest: digest, current_spot: spot)
       user = User.new(user_attrs)
       return if user.admin? && User.exists?(buck_id: user.buck_id)
       user.save

--- a/app/models/user/loader.rb
+++ b/app/models/user/loader.rb
@@ -57,8 +57,8 @@ class User
       PasswordResetRequest.destroy_all
       DisciplineAction.destroy_all
       Performance.destroy_all
-      Spot.destroy_all
       User.where.not(role: :admin).destroy_all
+      Spot.destroy_all
     end
 
     def create_spot_from_row(row)

--- a/app/models/user_challenge.rb
+++ b/app/models/user_challenge.rb
@@ -17,6 +17,6 @@ class UserChallenge < ApplicationRecord
   # for non open spot challenges only
   def self.user_being_challenged?(user, challenge)
     return false if user.alternate?
-    user.spot == challenge.spot
+    user.current_spot == challenge.spot
   end
 end

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -7,6 +7,6 @@ json.role user.role.camelcase
 json.instrument user.instrument.titleize
 json.part user.part.titleize
 
-json.spot do
-  json.partial! 'spots/spot', spot: user.spot
+json.current_spot do
+  json.partial! 'spots/spot', spot: user.current_spot
 end

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -10,3 +10,7 @@ json.part user.part.titleize
 json.current_spot do
   json.partial! 'spots/spot', spot: user.current_spot
 end
+
+json.original_spot do
+  json.partial! 'spots/spot', spot: user.original_spot
+end

--- a/app/views/users/profile.json.jbuilder
+++ b/app/views/users/profile.json.jbuilder
@@ -11,7 +11,7 @@ else
     json.partial! 'performances/performance', performance: @next_performance
   end
 
-  if @user.challenges.length <= 0 || @user.challenges.last.spot == @user.spot
+  if @user.challenges.length <= 0 || @user.challenges.last.spot == @user.current_spot
     json.current_challenge nil
   elsif !@user.challenges.last.nil? && @user.challenges.last.performance.id == @next_performance.id
     json.current_challenge do

--- a/client/src/components/discipline_action/components/create.jsx
+++ b/client/src/components/discipline_action/components/create.jsx
@@ -124,8 +124,8 @@ export default class CreateDisciplineAction extends React.PureComponent {
           getRef={ref => {
             this.openSpot = ref;
           }}
-          label={`Check box if the spot ${user.spot.row}${user.spot
-            .file} opens as a result of the action`}
+          label={`Check box if the spot ${user.currentSpot.row}${user
+            .currentSpot.file} opens as a result of the action`}
         />
         <Checkbox
           getRef={ref => {

--- a/client/src/components/user_header/index.jsx
+++ b/client/src/components/user_header/index.jsx
@@ -4,7 +4,7 @@ import pick from 'lodash.pick';
 
 import { helpers, propTypes as userPropTypes } from '../../data/user';
 
-const props = ['firstName', 'lastName', 'role', 'spot'];
+const props = ['firstName', 'lastName', 'role', 'currentSpot'];
 
 const Container = styled.div`
   display: flex;
@@ -43,7 +43,8 @@ const UserHeader = userProps =>
     {helpers.isAdmin(userProps) || helpers.isDirector(userProps)
       ? <AdminTag>Admin</AdminTag>
       : <SpotCircle>
-          <SpotText>{`${userProps.spot.row}${userProps.spot.file}`}</SpotText>
+          <SpotText>{`${userProps.currentSpot.row}${userProps.currentSpot
+            .file}`}</SpotText>
         </SpotCircle>}
     <NameHeader>
       {`${userProps.firstName} ${userProps.lastName}`}
@@ -54,7 +55,7 @@ UserHeader.propTypes = pick(userPropTypes, [
   'firstName',
   'lastName',
   'role',
-  'spot'
+  'currentSpot'
 ]);
 UserHeader.props = props;
 

--- a/client/src/data/user/helpers.js
+++ b/client/src/data/user/helpers.js
@@ -61,7 +61,7 @@ const isAdmin = ({ role }) => role === ADMIN;
 const isDirector = ({ role }) => role === DIRECTOR;
 const isMember = ({ role }) => role === MEMBER;
 const isSquadLeader = ({ role }) => role === SQUAD_LEADER;
-const isTriChallengeUser = ({ spot }) => ['J'].includes(spot.row);
+const isTriChallengeUser = ({ currentSpot }) => ['J'].includes(currentSpot.row);
 const resetPassword = (password_reset_request_id, password, { id }) =>
   api.post(`/users/${id}/reset_password`, {
     password_reset_request_id,

--- a/client/src/data/user/propTypes.js
+++ b/client/src/data/user/propTypes.js
@@ -11,7 +11,7 @@ const propTypes = {
   lastName: PropTypes.string.isRequired,
   part: PropTypes.oneOf(Object.values(helpers.parts)).isRequired,
   role: PropTypes.oneOf(Object.values(helpers.roles)),
-  spot: PropTypes.shape(spotProps)
+  current_spot: PropTypes.shape(spotProps)
 };
 
 export default propTypes;

--- a/client/src/scenes/performance/challenge_select/components/users_can_challenge.jsx
+++ b/client/src/scenes/performance/challenge_select/components/users_can_challenge.jsx
@@ -80,8 +80,8 @@ export default class UsersCanChallenge extends React.PureComponent {
                       <b>
                         {user.firstName} {user.lastName}
                       </b>
-                      &nbsp;({user.spot.row}
-                      {user.spot.file})
+                      &nbsp;({user.currentSpot.row}
+                      {user.currentSpot.file})
                     </Typography>
                   </ListItem>
                 </UserContainer>

--- a/client/src/scenes/user/profile/components/challenge.jsx
+++ b/client/src/scenes/user/profile/components/challenge.jsx
@@ -35,7 +35,7 @@ export default function Challenge({ performanceName, spot, userChallenge }) {
         </Header>
         <UserChallenge
           {...userChallenge}
-          hideName={true}
+          hideName
           style={{
             width: '100%'
           }}

--- a/client/src/scenes/user/profile_admin/index.jsx
+++ b/client/src/scenes/user/profile_admin/index.jsx
@@ -76,7 +76,7 @@ class Profile extends React.PureComponent {
       (Boolean(performance) && disciplineActions.length <= 0) ||
       (disciplineActions.length >= 1 &&
         disciplineActions[disciplineActions.length - 1].performance.id !==
-          performance.id);
+          (performance && performance.id));
 
     return (
       <FlexContainer

--- a/client/src/scenes/user/roster/index.jsx
+++ b/client/src/scenes/user/roster/index.jsx
@@ -20,7 +20,10 @@ const Container = styled.div`
 const filterMethod = ({ id, value }, row) =>
   row[id].toLowerCase().includes(value.toLowerCase());
 const flattenSpotToString = oldUsers =>
-  oldUsers.map(({ spot, ...a }) => ({ spot: `${spot.row}${spot.file}`, ...a }));
+  oldUsers.map(({ currentSpot, ...a }) => ({
+    spot: `${currentSpot.row}${currentSpot.file}`,
+    ...a
+  }));
 const updateStateWithNewRow = newRow => ({ users }) => {
   const newSpot = newRow.spot;
   let oldSpot, oldSpotUserIndex; // index at which the user who currently holds `newSpot` resides

--- a/client/src/scenes/user/roster/index.jsx
+++ b/client/src/scenes/user/roster/index.jsx
@@ -90,6 +90,14 @@ export default class Roster extends React.PureComponent {
     return <EditSpot {...props} onChange={this.handleRowChange} />;
   }
 
+  renderOriginalSpot(props) {
+    return (
+      <span>
+        {props.value.row.toUpperCase()}{props.value.file}
+      </span>
+    );
+  }
+
   render() {
     const { users } = this.state;
     const columns = [
@@ -111,12 +119,18 @@ export default class Roster extends React.PureComponent {
         ]
       },
       {
-        header: 'Spot',
+        header: 'Spots',
         columns: [
           {
-            header: 'Spot',
+            header: 'Current',
             accessor: 'spot',
             render: this.renderEditSpot,
+            filterMethod
+          },
+          {
+            header: 'Original',
+            accessor: 'originalSpot',
+            render: this.renderOriginalSpot,
             filterMethod
           }
         ]

--- a/client/src/scenes/user/roster/index.jsx
+++ b/client/src/scenes/user/roster/index.jsx
@@ -20,8 +20,9 @@ const Container = styled.div`
 const filterMethod = ({ id, value }, row) =>
   row[id].toLowerCase().includes(value.toLowerCase());
 const flattenSpotToString = oldUsers =>
-  oldUsers.map(({ currentSpot, ...a }) => ({
-    spot: `${currentSpot.row}${currentSpot.file}`,
+  oldUsers.map(({ currentSpot, originalSpot, ...a }) => ({
+    currentSpot: `${currentSpot.row}${currentSpot.file}`,
+    originalSpot: `${originalSpot.row}${originalSpot.file}`,
     ...a
   }));
 const updateStateWithNewRow = newRow => ({ users }) => {
@@ -93,7 +94,7 @@ export default class Roster extends React.PureComponent {
   renderOriginalSpot(props) {
     return (
       <span>
-        {props.value.row.toUpperCase()}{props.value.file}
+        {props.value}
       </span>
     );
   }
@@ -123,7 +124,7 @@ export default class Roster extends React.PureComponent {
         columns: [
           {
             header: 'Current',
-            accessor: 'spot',
+            accessor: 'currentSpot',
             render: this.renderEditSpot,
             filterMethod
           },

--- a/db/migrate/20170926013227_rename_spot_to_current_spot.rb
+++ b/db/migrate/20170926013227_rename_spot_to_current_spot.rb
@@ -1,0 +1,5 @@
+class RenameSpotToCurrentSpot < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :users, :spot_id, :current_spot_id
+  end
+end

--- a/db/migrate/20170929220708_add_original_spot_to_user.rb
+++ b/db/migrate/20170929220708_add_original_spot_to_user.rb
@@ -1,0 +1,6 @@
+class AddOriginalSpotToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :original_spot_id, :integer, index: true
+    add_foreign_key :users, :spots, column: :original_spot_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170908015143) do
+ActiveRecord::Schema.define(version: 20170926013227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,13 +84,13 @@ ActiveRecord::Schema.define(version: 20170908015143) do
     t.integer  "part",                                       null: false
     t.integer  "role",                                       null: false
     t.datetime "password_updated",  default: -> { "now()" }, null: false
-    t.integer  "spot_id"
+    t.integer  "current_spot_id"
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
     t.datetime "revoke_token_date"
     t.index ["buck_id"], name: "index_users_on_buck_id", using: :btree
+    t.index ["current_spot_id"], name: "index_users_on_current_spot_id", using: :btree
     t.index ["email"], name: "index_users_on_email", using: :btree
-    t.index ["spot_id"], name: "index_users_on_spot_id", using: :btree
   end
 
   add_foreign_key "discipline_actions", "users", column: "user_buck_id", primary_key: "buck_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926013227) do
+ActiveRecord::Schema.define(version: 20170929220708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20170926013227) do
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
     t.datetime "revoke_token_date"
+    t.integer  "original_spot_id"
     t.index ["buck_id"], name: "index_users_on_buck_id", using: :btree
     t.index ["current_spot_id"], name: "index_users_on_current_spot_id", using: :btree
     t.index ["email"], name: "index_users_on_email", using: :btree
@@ -96,4 +97,5 @@ ActiveRecord::Schema.define(version: 20170926013227) do
   add_foreign_key "discipline_actions", "users", column: "user_buck_id", primary_key: "buck_id"
   add_foreign_key "password_reset_requests", "users", column: "user_buck_id", primary_key: "buck_id"
   add_foreign_key "user_challenges", "users", column: "user_buck_id", primary_key: "buck_id"
+  add_foreign_key "users", "spots", column: "original_spot_id"
 end

--- a/lib/seed/challenges.rb
+++ b/lib/seed/challenges.rb
@@ -18,12 +18,12 @@ def seed_challenges(performance)
     winner_id = row[2].value
     challenger_comments = row[3].value
     challengee_comments = row[4].value
-    challengee = User.where(spot: Spot.where(row: row_in_challenge, file: file_in_challenge)).first
+    challengee = User.where(current_spot: Spot.where(row: row_in_challenge, file: file_in_challenge)).first
     challenge.users = [challenger, challengee]
-    challenge.user_challenges[0].spot = challenger.spot
+    challenge.user_challenges[0].spot = challenger.current_spot
     challenge.user_challenges[0].comments = challenger_comments
     challenge.user_challenges[0].place = winner_id == challenger.buck_id ? :first : :second
-    challenge.user_challenges[1].spot = challengee.spot
+    challenge.user_challenges[1].spot = challengee.current_spot
     challenge.user_challenges[1].comments = challengee_comments
     challenge.user_challenges[1].place = winner_id == challengee.buck_id ? :first : :second
     challenges << challenge

--- a/lib/seed/users.rb
+++ b/lib/seed/users.rb
@@ -16,6 +16,7 @@ def seed_users
     buck_id = row[6].value.downcase
     role = row[7].value.split(' ').join('').underscore
     email = row[9].value.downcase
+    spot = Spot.where(row: Spot.rows[user_row], file: user_file)[0]
     user = User.new(
       first_name: first_name,
       last_name: last_name,
@@ -25,7 +26,8 @@ def seed_users
       role: User.roles[role],
       password_digest: password_digest,
       email: email,
-      spot: Spot.where(row: Spot.rows[user_row], file: user_file)[0]
+      current_spot: spot,
+      original_spot: spot
     )
     i += 1
     users << user

--- a/lib/sql/performance/challengeable_users.sql
+++ b/lib/sql/performance/challengeable_users.sql
@@ -31,7 +31,7 @@ JOIN (
   ) disciplines_for_performance
   ON users.buck_id = disciplines_for_performance.user_buck_id
   WHERE users.instrument = %{instrument} AND users.part = %{part} AND NOT users.buck_id = '%{buck_id}'
-) users_disciplines ON s.id = users_disciplines.spot_id
+) users_disciplines ON s.id = users_disciplines.current_spot_id
 LEFT OUTER JOIN user_challenges AS uc ON c.id = uc.challenge_id
 WHERE s.file < 13
 GROUP BY

--- a/spec/factories/challenges.rb
+++ b/spec/factories/challenges.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
     users {
       [
         FactoryGirl.create(:user, :spot_a13, :trumpet, :solo),
-        FactoryGirl.create(:user, :trumpet, :solo, current_spot: spot)
+        FactoryGirl.create(:user, :trumpet, :solo, current_spot: spot, original_spot: spot)
       ]
     }
   end

--- a/spec/factories/challenges.rb
+++ b/spec/factories/challenges.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     performance { FactoryGirl.create(:performance) }
     after(:build) do |c|
       c.user_challenges.each do |uc|
-        uc.spot = uc.user.spot
+        uc.spot = uc.user.current_spot
       end
     end
   end
@@ -31,7 +31,7 @@ FactoryGirl.define do
     users {
       [
         FactoryGirl.create(:user, :spot_a13, :trumpet, :solo),
-        FactoryGirl.create(:user, :trumpet, :solo, spot: spot)
+        FactoryGirl.create(:user, :trumpet, :solo, current_spot: spot)
       ]
     }
   end
@@ -43,7 +43,7 @@ FactoryGirl.define do
       [
         FactoryGirl.create(:user, :spot_j15, :percussion, :bass),
         FactoryGirl.create(:user, :spot_j17, :percussion, :bass),
-        FactoryGirl.create(:user, :percussion, :bass, spot: spot)
+        FactoryGirl.create(:user, :percussion, :bass, current_spot: spot)
       ]
     }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,9 @@ FactoryGirl.define do
     role User.roles[:member]
     password_updated Time.zone.now
     association :current_spot, factory: :spot, row: :a, file: 2
+    original_spot do
+      current_spot
+    end
 
     trait :director do
       role User.roles[:director]

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,21 +13,21 @@ FactoryGirl.define do
     part User.parts[:solo]
     role User.roles[:member]
     password_updated Time.zone.now
-    association :spot, row: Spot.rows[:a], file: 2
+    association :current_spot, factory: :spot, row: :a, file: 2
 
     trait :director do
       role User.roles[:director]
-      spot nil
+      association :current_spot, factory: :spot, strategy: :null
     end
 
     trait :admin do
       role User.roles[:admin]
-      spot nil
+      association :current_spot, factory: :spot, strategy: :null
     end
 
     trait :squad_leader do
       role User.roles[:squad_leader]
-      association :spot, row: Spot.rows[:a], file: 1
+      association :current_spot, factory: :spot, row: :a, file: 1
     end
 
     trait :member do
@@ -35,7 +35,7 @@ FactoryGirl.define do
     end
 
     trait :alternate do
-      association :spot, file: 13
+      association :current_spot, factory: :spot, file: 13
     end
 
     User.instruments.each do |name, value|
@@ -52,14 +52,14 @@ FactoryGirl.define do
 
     Spot.rows.each do |name, value|
       trait "#{name}_row".to_sym do
-        association :spot, row: value
+        association :current_spot, factory: :spot, row: value
       end
     end
 
     Spot.rows.each do |name, value|
       (1..18).each do |file|
         trait "spot_#{name}#{file}".to_sym do
-          association :spot, row: value, file: file
+          association :current_spot, factory: :spot, row: value, file: file
         end
       end
     end

--- a/spec/models/challenge/bylder_spec.rb
+++ b/spec/models/challenge/bylder_spec.rb
@@ -6,7 +6,7 @@ describe 'Challenge::Bylder' do
   context 'Normal Challenge' do
     let!(:spot) { create(:spot, row: :a, file: 1) }
     let!(:challenger) { create(:user, :spot_a13, :trumpet, :solo) }
-    let!(:challengee) { create(:user, :trumpet, :solo, spot: spot) }
+    let!(:challengee) { create(:user, :trumpet, :solo, current_spot: spot) }
 
     it 'creates a valid normal challenge' do
       challenge = Challenge::Bylder.perform challenger, performance, spot
@@ -18,7 +18,7 @@ describe 'Challenge::Bylder' do
 
   context 'Open Spot Challenge' do
     let!(:spot) { create(:spot, row: :a, file: 1) }
-    let!(:challengee) { create(:user, :trumpet, :solo, spot: spot) }
+    let!(:challengee) { create(:user, :trumpet, :solo, current_spot: spot) }
     let!(:challenger) { create(:user, :spot_a13, :trumpet, :solo) }
     let!(:user_da) { create(:discipline_action, user: challengee, performance: performance) }
     let!(:challenge) {
@@ -47,7 +47,7 @@ describe 'Challenge::Bylder' do
 
   context 'Tri Challenge' do
     let!(:spot) { create(:spot, row: :j, file: 1) }
-    let!(:challengee) { create(:user, :percussion, :bass, spot: spot) }
+    let!(:challengee) { create(:user, :percussion, :bass, current_spot: spot) }
     let!(:challenger) { create(:user, :spot_j13, :percussion, :bass) }
     let!(:other_challenger) { create(:user, :spot_j17, :percussion, :bass) }
 

--- a/spec/models/challenge/spot_switcher_spec.rb
+++ b/spec/models/challenge/spot_switcher_spec.rb
@@ -5,7 +5,7 @@ describe 'Challenge::SpotSwitcher' do
     let!(:challenge) { create(:normal_challenge) }
     let!(:winner) { challenge.users.select(&:alternate?).first }
     let!(:loser) { challenge.users.reject(&:alternate?).first }
-    let!(:spot_for_loser) { winner.spot }
+    let!(:spot_for_loser) { winner.current_spot }
 
     before do
       challenge.user_challenges.each do |uc|
@@ -23,8 +23,8 @@ describe 'Challenge::SpotSwitcher' do
 
       winner.reload
       loser.reload
-      expect(winner.spot).to eq(challenge.spot)
-      expect(loser.spot).to eq(spot_for_loser)
+      expect(winner.current_spot).to eq(challenge.spot)
+      expect(loser.current_spot).to eq(spot_for_loser)
     end
   end
 
@@ -33,10 +33,10 @@ describe 'Challenge::SpotSwitcher' do
       let!(:challenge) { create(:full_open_spot_challenge) }
       let!(:winner) { challenge.users.first }
       let!(:loser) { challenge.users.last }
-      let!(:user_of_challenge_spot) { create(:user, spot: challenge.spot) }
+      let!(:user_of_challenge_spot) { create(:user, current_spot: challenge.spot) }
       let!(:spot_for_winner) { challenge.spot }
-      let!(:spot_for_loser) { loser.spot }
-      let!(:spot_for_user_of_challenge_spot) { winner.spot }
+      let!(:spot_for_loser) { loser.current_spot }
+      let!(:spot_for_user_of_challenge_spot) { winner.current_spot }
 
       before do
         challenge.user_challenges.each_with_index do |uc, index|
@@ -51,9 +51,9 @@ describe 'Challenge::SpotSwitcher' do
         winner.reload
         loser.reload
         user_of_challenge_spot.reload
-        expect(winner.spot).to eq(spot_for_winner)
-        expect(loser.spot).to eq(spot_for_loser)
-        expect(user_of_challenge_spot.spot).to eq(spot_for_user_of_challenge_spot)
+        expect(winner.current_spot).to eq(spot_for_winner)
+        expect(loser.current_spot).to eq(spot_for_loser)
+        expect(user_of_challenge_spot.current_spot).to eq(spot_for_user_of_challenge_spot)
       end
     end
 
@@ -62,17 +62,17 @@ describe 'Challenge::SpotSwitcher' do
       let!(:normal_challenge_spot) { create(:spot, row: :a, file: 11) }
       let!(:open_spot_winner) { open_spot_challenge.users.first }
       let!(:open_spot_loser) { open_spot_challenge.users.last }
-      let!(:user_of_open_challenge_spot) { create(:user, spot: open_spot_challenge.spot) }
-      let!(:user_of_normal_challenge_spot) { create(:user, spot: normal_challenge_spot) }
+      let!(:user_of_open_challenge_spot) { create(:user, current_spot: open_spot_challenge.spot) }
+      let!(:user_of_normal_challenge_spot) { create(:user, current_spot: normal_challenge_spot) }
       let!(:spot_for_open_spot_winner) { open_spot_challenge.spot }
-      let!(:spot_for_open_spot_loser) { open_spot_loser.spot }
+      let!(:spot_for_open_spot_loser) { open_spot_loser.current_spot }
       let!(:normal_challenge) {
         Challenge::Bylder.perform(user_of_open_challenge_spot, open_spot_challenge.performance, normal_challenge_spot)
       }
 
       context 'and that user loses' do
         let!(:spot_for_normal_winner) { normal_challenge_spot }
-        let!(:spot_for_normal_loser) { open_spot_winner.spot }
+        let!(:spot_for_normal_loser) { open_spot_winner.current_spot }
 
         before do
           open_spot_challenge.user_challenges.each_with_index do |uc, index|
@@ -97,15 +97,15 @@ describe 'Challenge::SpotSwitcher' do
           user_of_open_challenge_spot.reload
           user_of_normal_challenge_spot.reload
 
-          expect(open_spot_winner.spot).to eq(spot_for_open_spot_winner)
-          expect(open_spot_loser.spot).to eq(spot_for_open_spot_loser)
-          expect(user_of_open_challenge_spot.spot).to eq(spot_for_normal_loser)
-          expect(user_of_normal_challenge_spot.spot).to eq(spot_for_normal_winner)
+          expect(open_spot_winner.current_spot).to eq(spot_for_open_spot_winner)
+          expect(open_spot_loser.current_spot).to eq(spot_for_open_spot_loser)
+          expect(user_of_open_challenge_spot.current_spot).to eq(spot_for_normal_loser)
+          expect(user_of_normal_challenge_spot.current_spot).to eq(spot_for_normal_winner)
         end
       end
 
       context 'and that user wins' do
-        let!(:spot_for_normal_winner) { open_spot_winner.spot }
+        let!(:spot_for_normal_winner) { open_spot_winner.current_spot }
         let!(:spot_for_normal_loser) { normal_challenge_spot }
 
         before do
@@ -131,10 +131,10 @@ describe 'Challenge::SpotSwitcher' do
           user_of_open_challenge_spot.reload
           user_of_normal_challenge_spot.reload
 
-          expect(open_spot_winner.spot).to eq(spot_for_open_spot_winner)
-          expect(open_spot_loser.spot).to eq(spot_for_open_spot_loser)
-          expect(user_of_open_challenge_spot.spot).to eq(spot_for_normal_loser)
-          expect(user_of_normal_challenge_spot.spot).to eq(spot_for_normal_winner)
+          expect(open_spot_winner.current_spot).to eq(spot_for_open_spot_winner)
+          expect(open_spot_loser.current_spot).to eq(spot_for_open_spot_loser)
+          expect(user_of_open_challenge_spot.current_spot).to eq(spot_for_normal_loser)
+          expect(user_of_normal_challenge_spot.current_spot).to eq(spot_for_normal_winner)
         end
       end
     end
@@ -145,11 +145,11 @@ describe 'Challenge::SpotSwitcher' do
 
     context 'the challenge places are in the order the members are already alternates' do
       let(:first_place) { challenge.users.reject(&:alternate?).first }
-      let(:second_place) { challenge.users.sort { |a, b| a.spot.file - b.spot.file }.select(&:alternate?).first }
+      let(:second_place) { challenge.users.sort { |a, b| a.current_spot.file - b.current_spot.file }.select(&:alternate?).first }
       let(:third_place) { challenge.users.select { |u| u != first_place && u != second_place }.first }
-      let(:first_place_spot) { first_place.spot }
-      let(:second_place_spot) { second_place.spot }
-      let(:third_place_spot) { third_place.spot }
+      let(:first_place_spot) { first_place.current_spot }
+      let(:second_place_spot) { second_place.current_spot }
+      let(:third_place_spot) { third_place.current_spot }
 
       before do
         challenge.user_challenges.each_with_index do |uc, index|
@@ -164,20 +164,20 @@ describe 'Challenge::SpotSwitcher' do
         second_place.reload
         third_place.reload
 
-        expect(first_place.spot).to eq(first_place_spot)
-        expect(second_place.spot).to eq(second_place_spot)
-        expect(third_place.spot).to eq(third_place_spot)
+        expect(first_place.current_spot).to eq(first_place_spot)
+        expect(second_place.current_spot).to eq(second_place_spot)
+        expect(third_place.current_spot).to eq(third_place_spot)
       end
     end
 
     context 'the regular wins, but the alternate with the higher spot wins' do
       let!(:first_place) { challenge.users.reject(&:alternate?).first }
-      let!(:second_place) { challenge.users.sort { |a, b| a.spot.file - b.spot.file }.select(&:alternate?).last }
+      let!(:second_place) { challenge.users.sort { |a, b| a.current_spot.file - b.current_spot.file }.select(&:alternate?).last }
       let!(:third_place) { challenge.users.select { |u| u != first_place && u != second_place }.first }
-      let!(:first_place_spot) { first_place.spot }
+      let!(:first_place_spot) { first_place.current_spot }
       # second and third place should switch spots
-      let!(:second_place_spot) { third_place.spot }
-      let!(:third_place_spot) { second_place.spot }
+      let!(:second_place_spot) { third_place.current_spot }
+      let!(:third_place_spot) { second_place.current_spot }
 
       before do
         challenge.user_challenges.each do |uc|
@@ -199,20 +199,20 @@ describe 'Challenge::SpotSwitcher' do
         second_place.reload
         third_place.reload
 
-        expect(first_place.spot).to eq(first_place_spot)
-        expect(second_place.spot).to eq(second_place_spot)
-        expect(third_place.spot).to eq(third_place_spot)
+        expect(first_place.current_spot).to eq(first_place_spot)
+        expect(second_place.current_spot).to eq(second_place_spot)
+        expect(third_place.current_spot).to eq(third_place_spot)
       end
     end
 
     context 'the lowest alternate wins and the regular comes in 3rd place' do
-      let!(:first_place) { challenge.users.sort { |a, b| a.spot.file - b.spot.file }.select(&:alternate?).last }
-      let!(:second_place) { challenge.users.sort { |a, b| a.spot.file - b.spot.file }.select(&:alternate?).first }
+      let!(:first_place) { challenge.users.sort { |a, b| a.current_spot.file - b.current_spot.file }.select(&:alternate?).last }
+      let!(:second_place) { challenge.users.sort { |a, b| a.current_spot.file - b.current_spot.file }.select(&:alternate?).first }
       let!(:third_place) { challenge.users.reject(&:alternate?).first }
       # first and third place should switch spots
-      let!(:first_place_spot) { third_place.spot }
-      let!(:second_place_spot) { second_place.spot }
-      let!(:third_place_spot) { first_place.spot }
+      let!(:first_place_spot) { third_place.current_spot }
+      let!(:second_place_spot) { second_place.current_spot }
+      let!(:third_place_spot) { first_place.current_spot }
 
       before do
         challenge.user_challenges.each do |uc|
@@ -234,20 +234,20 @@ describe 'Challenge::SpotSwitcher' do
         second_place.reload
         third_place.reload
 
-        expect(first_place.spot).to eq(first_place_spot)
-        expect(second_place.spot).to eq(second_place_spot)
-        expect(third_place.spot).to eq(third_place_spot)
+        expect(first_place.current_spot).to eq(first_place_spot)
+        expect(second_place.current_spot).to eq(second_place_spot)
+        expect(third_place.current_spot).to eq(third_place_spot)
       end
     end
 
     context 'the lowest alternate wins and the regular comes in second' do
-      let!(:first_place) { challenge.users.sort { |a, b| a.spot.file - b.spot.file }.select(&:alternate?).last }
+      let!(:first_place) { challenge.users.sort { |a, b| a.current_spot.file - b.current_spot.file }.select(&:alternate?).last }
       let!(:second_place) { challenge.users.reject(&:alternate?).first }
-      let!(:third_place) { challenge.users.sort { |a, b| a.spot.file - b.spot.file }.select(&:alternate?).first }
+      let!(:third_place) { challenge.users.sort { |a, b| a.current_spot.file - b.current_spot.file }.select(&:alternate?).first }
       # first and third place should switch spots
-      let!(:first_place_spot) { second_place.spot }
-      let!(:second_place_spot) { third_place.spot }
-      let!(:third_place_spot) { first_place.spot }
+      let!(:first_place_spot) { second_place.current_spot }
+      let!(:second_place_spot) { third_place.current_spot }
+      let!(:third_place_spot) { first_place.current_spot }
 
       before do
         challenge.user_challenges.each do |uc|
@@ -269,9 +269,9 @@ describe 'Challenge::SpotSwitcher' do
         second_place.reload
         third_place.reload
 
-        expect(first_place.spot).to eq(first_place_spot)
-        expect(second_place.spot).to eq(second_place_spot)
-        expect(third_place.spot).to eq(third_place_spot)
+        expect(first_place.current_spot).to eq(first_place_spot)
+        expect(second_place.current_spot).to eq(second_place_spot)
+        expect(third_place.current_spot).to eq(third_place_spot)
       end
     end
   end

--- a/spec/models/challenge_spec.rb
+++ b/spec/models/challenge_spec.rb
@@ -205,14 +205,14 @@ describe Challenge, type: :model do
     let!(:challenge) { create(:normal_challenge, spot: create(:spot, row: :x, file: 1)) }
     let(:current_instrument) { challenge.users.first.instrument }
     let(:spot_in_challenge_row) { create(:spot, row: challenge.spot.row, file: 2) }
-    let(:spot_in_first_user_row) { create(:spot, row: challenge.users.first.spot.row, file: 2) }
-    let(:spot_in_last_user_row) { create(:spot, row: challenge.users.last.spot.row, file: 2) }
+    let(:spot_in_first_user_row) { create(:spot, row: challenge.users.first.current_spot.row, file: 2) }
+    let(:spot_in_last_user_row) { create(:spot, row: challenge.users.last.current_spot.row, file: 2) }
     let(:last_user_row) { challenge.users.last.spot.row }
     let(:other_instrument) do
       User.instruments.find { |key, _value| key != current_instrument && key != 'any' }.first.to_sym
     end
     let(:spot_in_other_row) do
-      taken_spots = challenge.users.map { |user| user.spot.row }
+      taken_spots = challenge.users.map { |user| user.current_spot.row }
       row = Spot.rows.find { |key, _value| !taken_spots.include?(key) }.first.to_sym
       create(:spot, row: row, file: 2)
     end
@@ -255,7 +255,7 @@ describe Challenge, type: :model do
     context 'when a squad leader is evaluating' do
       context 'and they are in the row of the challenge' do
         let(:user) do
-          create(:user, :squad_leader, instrument: current_instrument, spot: spot_in_challenge_row)
+          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_challenge_row)
         end
 
         specify { expect(described_class.viewable_by_user(user)).to include(challenge) }
@@ -264,10 +264,10 @@ describe Challenge, type: :model do
 
       context 'and they are in the row of one of the participants' do
         let(:user_1) do
-          create(:user, :squad_leader, instrument: current_instrument, spot: spot_in_first_user_row)
+          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_first_user_row)
         end
         let(:user_2) do
-          create(:user, :squad_leader, instrument: current_instrument, spot: spot_in_last_user_row)
+          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_last_user_row)
         end
 
         specify { expect(described_class.viewable_by_user(user_1)).to include(challenge) }
@@ -280,7 +280,7 @@ describe Challenge, type: :model do
 
       context 'and they are in an entirely different row' do
         let(:user) do
-          create(:user, :squad_leader, instrument: :trumpet, part: :first, spot: spot_in_other_row)
+          create(:user, :squad_leader, instrument: :trumpet, part: :first, current_spot: spot_in_other_row)
         end
 
         specify { expect(described_class.viewable_by_user(user)).to be_empty }
@@ -298,7 +298,7 @@ describe Challenge, type: :model do
       create(
         :normal_challenge,
         spot: spot,
-        users: [create(:user, :solo, :trumpet, spot: spot), create(:user, :spot_a14, :solo, :trumpet)],
+        users: [create(:user, :solo, :trumpet, current_spot: spot), create(:user, :spot_a14, :solo, :trumpet)],
         stage: :needs_comments
       )
     end
@@ -335,7 +335,7 @@ describe Challenge, type: :model do
       create(
         :normal_challenge,
         spot: spot,
-        users: [create(:user, :solo, :trumpet, spot: spot), create(:user, :spot_a14, :solo, :trumpet)],
+        users: [create(:user, :solo, :trumpet, current_spot: spot), create(:user, :spot_a14, :solo, :trumpet)],
         stage: :done
       )
     end
@@ -344,7 +344,7 @@ describe Challenge, type: :model do
       create(
         :normal_challenge,
         spot: spot,
-        users: [create(:user, :solo, :trumpet, spot: spot), create(:user, :spot_x13, :solo, :trumpet)],
+        users: [create(:user, :solo, :trumpet, current_spot: spot), create(:user, :spot_x13, :solo, :trumpet)],
         stage: :done
       )
     end

--- a/spec/models/challenge_spec.rb
+++ b/spec/models/challenge_spec.rb
@@ -205,9 +205,8 @@ describe Challenge, type: :model do
     let!(:challenge) { create(:normal_challenge, spot: create(:spot, row: :x, file: 1)) }
     let(:current_instrument) { challenge.users.first.instrument }
     let(:spot_in_challenge_row) { create(:spot, row: challenge.spot.row, file: 2) }
-    let(:spot_in_first_user_row) { create(:spot, row: challenge.users.first.current_spot.row, file: 2) }
-    let(:spot_in_last_user_row) { create(:spot, row: challenge.users.last.current_spot.row, file: 2) }
-    let(:last_user_row) { challenge.users.last.spot.row }
+    let(:spot_in_first_user_row) { create(:spot, row: challenge.users.first.original_spot.row, file: 2) }
+    let(:spot_in_last_user_row) { create(:spot, row: challenge.users.last.original_spot.row, file: 2) }
     let(:other_instrument) do
       User.instruments.find { |key, _value| key != current_instrument && key != 'any' }.first.to_sym
     end
@@ -264,10 +263,10 @@ describe Challenge, type: :model do
 
       context 'and they are in the row of one of the participants' do
         let(:user_1) do
-          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_first_user_row)
+          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_first_user_row, original_spot: spot_in_first_user_row)
         end
         let(:user_2) do
-          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_last_user_row)
+          create(:user, :squad_leader, instrument: current_instrument, current_spot: spot_in_last_user_row, original_spot: spot_in_last_user_row)
         end
 
         specify { expect(described_class.viewable_by_user(user_1)).to include(challenge) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,7 @@ describe User, type: :model do
   it { is_expected.to validate_presence_of(:instrument) }
   it { is_expected.to validate_presence_of(:part) }
   it { is_expected.to validate_presence_of(:role) }
-  it { is_expected.to validate_presence_of(:spot) }
+  it { is_expected.to validate_presence_of(:current_spot) }
 
   describe 'callbacks' do
     let(:user) { create(:user, email: email) }
@@ -35,7 +35,7 @@ describe User, type: :model do
   describe 'validations' do
     it 'does not allow multiple users to share a spot' do
       user_a = create(:user)
-      user_b = build(:user, spot: user_a.spot)
+      user_b = build(:user, current_spot: user_a.current_spot)
       expect(user_b).not_to be_valid
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,7 @@ describe User, type: :model do
   it { is_expected.to validate_presence_of(:part) }
   it { is_expected.to validate_presence_of(:role) }
   it { is_expected.to validate_presence_of(:current_spot) }
+  it { is_expected.to validate_presence_of(:original_spot) }
 
   describe 'callbacks' do
     let(:user) { create(:user, email: email) }

--- a/spec/requests/challenge_creation_spec.rb
+++ b/spec/requests/challenge_creation_spec.rb
@@ -12,8 +12,8 @@ describe 'Challenge Creation', type: :request do
   let(:params) do
     {
       spot: {
-        row: challengee.spot.row.upcase,
-        file: challengee.spot.file
+        row: challengee.current_spot.row.upcase,
+        file: challengee.current_spot.file
       }
     }
   end
@@ -24,7 +24,7 @@ describe 'Challenge Creation', type: :request do
         let(:params) do
           {
             spot: {
-              row: challengee.spot.row.upcase,
+              row: challengee.current_spot.row.upcase,
               file: 13
             }
           }
@@ -96,8 +96,8 @@ describe 'Challenge Creation', type: :request do
           {
             challenge_type: 'normal',
             spot: {
-              row: other_challengee.spot.row.upcase,
-              file: other_challengee.spot.file
+              row: other_challengee.current_spot.row.upcase,
+              file: other_challengee.current_spot.file
             },
             performance_id: performance.id
           }
@@ -121,8 +121,8 @@ describe 'Challenge Creation', type: :request do
         {
           challenger_buck_id: challenger.buck_id,
           spot: {
-            row: challengee.spot.row.upcase,
-            file: challengee.spot.file
+            row: challengee.current_spot.row.upcase,
+            file: challengee.current_spot.file
           }
         }
       end
@@ -137,8 +137,8 @@ describe 'Challenge Creation', type: :request do
 
           expect(challenge).to include('challenge_type' => 'normal',
                                        'spot' => {
-                                         'row' => challengee.spot.row.upcase,
-                                         'file' => challengee.spot.file
+                                         'row' => challengee.current_spot.row.upcase,
+                                         'file' => challengee.current_spot.file
                                        },
                                        'users' => contain_exactly(
                                          include('id' => challenger.id),
@@ -155,8 +155,8 @@ describe 'Challenge Creation', type: :request do
           {
             challenger_buck_id: challenger.buck_id,
             spot: {
-              row: challengee.spot.row.upcase,
-              file: challengee.spot.file
+              row: challengee.current_spot.row.upcase,
+              file: challengee.current_spot.file
             }
           }
         end
@@ -170,8 +170,8 @@ describe 'Challenge Creation', type: :request do
 
           expect(challenge).to include('challenge_type' => 'tri',
                                        'spot' => {
-                                         'row' => challengee.spot.row.upcase,
-                                         'file' => challengee.spot.file
+                                         'row' => challengee.current_spot.row.upcase,
+                                         'file' => challengee.current_spot.file
                                        },
                                        'users' => contain_exactly(
                                          include('id' => challenger.id),
@@ -195,8 +195,8 @@ describe 'Challenge Creation', type: :request do
 
           expect(challenge).to include('challenge_type' => 'open_spot',
                                        'spot' => {
-                                         'row' => challengee.spot.row.upcase,
-                                         'file' => challengee.spot.file
+                                         'row' => challengee.current_spot.row.upcase,
+                                         'file' => challengee.current_spot.file
                                        },
                                        'users' => contain_exactly(
                                          include('id' => challenger.id)
@@ -209,8 +209,8 @@ describe 'Challenge Creation', type: :request do
       let(:params) do
         {
           spot: {
-            row: challengee.spot.row.upcase,
-            file: challengee.spot.file
+            row: challengee.current_spot.row.upcase,
+            file: challengee.current_spot.file
           }
         }
       end
@@ -225,8 +225,8 @@ describe 'Challenge Creation', type: :request do
 
           expect(challenge).to include('challenge_type' => 'normal',
                                        'spot' => {
-                                         'row' => challengee.spot.row.upcase,
-                                         'file' => challengee.spot.file
+                                         'row' => challengee.current_spot.row.upcase,
+                                         'file' => challengee.current_spot.file
                                        },
                                        'users' => contain_exactly(
                                          include('id' => challenger.id),
@@ -242,8 +242,8 @@ describe 'Challenge Creation', type: :request do
         let(:params) do
           {
             spot: {
-              row: challengee.spot.row.upcase,
-              file: challengee.spot.file
+              row: challengee.current_spot.row.upcase,
+              file: challengee.current_spot.file
             }
           }
         end
@@ -257,8 +257,8 @@ describe 'Challenge Creation', type: :request do
 
           expect(challenge).to include('challenge_type' => 'tri',
                                        'spot' => {
-                                         'row' => challengee.spot.row.upcase,
-                                         'file' => challengee.spot.file
+                                         'row' => challengee.current_spot.row.upcase,
+                                         'file' => challengee.current_spot.file
                                        },
                                        'users' => contain_exactly(
                                          include('id' => challenger.id),
@@ -282,8 +282,8 @@ describe 'Challenge Creation', type: :request do
 
           expect(challenge).to include('challenge_type' => 'open_spot',
                                        'spot' => {
-                                         'row' => challengee.spot.row.upcase,
-                                         'file' => challengee.spot.file
+                                         'row' => challengee.current_spot.row.upcase,
+                                         'file' => challengee.current_spot.file
                                        },
                                        'users' => contain_exactly(
                                          include('id' => challenger.id)

--- a/spec/requests/discipline_actions_spec.rb
+++ b/spec/requests/discipline_actions_spec.rb
@@ -101,7 +101,7 @@ describe 'DisciplineActions', type: :request do
 
       context 'but the associated spot has already been challenged' do
         let!(:challenge) {
-          spot = discipline_action.user.spot
+          spot = discipline_action.user.current_spot
           create(:open_spot_challenge, spot: spot, performance: discipline_action.performance)
         }
 

--- a/spec/requests/user_challenges_spec.rb
+++ b/spec/requests/user_challenges_spec.rb
@@ -17,7 +17,7 @@ describe 'User Challenges', type: :request do
       let(:new_challenger) {
         create(
           :alternate_user,
-          "spot_#{challenger.spot.row}#{challenger.spot.file + 1}".to_sym,
+          "spot_#{challenger.current_spot.row}#{challenger.current_spot.file + 1}".to_sym,
           challenger.instrument.to_sym,
           challenger.part.to_sym
         )

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -123,35 +123,35 @@ describe 'User Requests', type: :request do
     let(:switch_params) do
       {
         user_buck_id: user.buck_id,
-        target_spot: target_user.spot
+        target_spot: target_user.current_spot
       }
     end
 
     it 'successfully switches two user\'s spots' do
       put switch_endpoint, params: switch_params.to_json, headers: authenticated_header(requesting_user)
 
-      old_user_spot = user.spot
+      old_user_spot = user.current_spot
       target_spot = switch_params[:target_spot]
       user.reload
       target_user.reload
 
       expect(response).to have_http_status(204)
-      expect(user.spot).to eq(target_spot)
-      expect(target_user.spot).to eq(old_user_spot)
+      expect(user.current_spot).to eq(target_spot)
+      expect(target_user.current_spot).to eq(old_user_spot)
     end
 
     context 'requesting user isn\'t an admin' do
       it 'returns a 403' do
         put switch_endpoint, params: switch_params.to_json, headers: authenticated_header(user)
 
-        user_spot = user.spot
+        user_spot = user.current_spot
         target_spot = switch_params[:target_spot]
         user.reload
         target_user.reload
 
         expect(response).to have_http_status(403)
-        expect(user.spot).to eq(user_spot)
-        expect(target_user.spot).to eq(target_spot)
+        expect(user.current_spot).to eq(user_spot)
+        expect(target_user.current_spot).to eq(target_spot)
       end
     end
 
@@ -169,11 +169,11 @@ describe 'User Requests', type: :request do
       it 'returns a 409' do
         put switch_endpoint, params: switch_params.to_json, headers: authenticated_header(requesting_user)
 
-        user_spot = user.spot
+        user_spot = user.current_spot
         user.reload
 
         expect(response).to have_http_status(409)
-        expect(user.spot).to eq(user_spot)
+        expect(user.current_spot).to eq(user_spot)
       end
     end
   end


### PR DESCRIPTION
Introduces the concept of `orginal_spot` versus and `current_spot`. When checking for viewable challenges, it will now check to see if the challenge spot is your row or if any challenges involve user's who's `original_row` is the same as a squad leader's