### PR TITLE
Removes formatting options for datetimepicker

### DIFF
--- a/app/views/performances/new.html.erb
+++ b/app/views/performances/new.html.erb
@@ -22,10 +22,9 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    const options = { format: 'm/d/y H:i' };
     document.getElementById('challenges--js__performance_form_timezone').value = jstz.determine().name();
-    jQuery('#challenges--js__performance_form_date').datetimepicker(options);
-    jQuery('#challenges--js__performance_form_window_open').datetimepicker(options);
-    jQuery('#challenges--js__performance_form_window_close').datetimepicker(options);
+    jQuery('#challenges--js__performance_form_date').datetimepicker();
+    jQuery('#challenges--js__performance_form_window_open').datetimepicker();
+    jQuery('#challenges--js__performance_form_window_close').datetimepicker();
   });
 </script>


### PR DESCRIPTION
[Trello](https://trello.com/c/WKxsHSkT/21-performancescreate-doesnt-work-in-safari)

It prevents the performance from being created correctly