### PR TITLE
Emails challenge users upon submission of results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
+  TargetRubyVersion: 2.5.1
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
-# rubocop:disable Style/FileName
 source 'https://rubygems.org'
 
-ruby File.read(File.dirname(__FILE__) + "/.ruby-version").strip
+ruby File.read(File.dirname(__FILE__) + '/.ruby-version').strip
 
 gem 'autoprefixer-rails', '8.2.0'
 gem 'bcrypt', '~> 3.1.7'
@@ -43,4 +42,3 @@ end
 group :test do
   gem 'database_cleaner', require: false
 end
-# rubocop:enable Style/FileName

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -54,6 +54,7 @@ class ChallengesController < ApplicationController # rubocop:disable Metrics/Cla
     elsif params['update_type'] == 'Submit'
       ChallengeService.move_to_next_stage(challenge_id: params['id'])
       CheckOtherChallengesDoneJob.perform_later(challenge_id: params['id'])
+      NotifyChallengeCompletionJob.perform_later(challenge_id: params['id'])
       redirect_to('/challenges/evaluate', flash: { message: I18n.t!('client_messages.challenges.evaluate.success') })
     end
   end

--- a/app/jobs/notify_challenge_completion_job.rb
+++ b/app/jobs/notify_challenge_completion_job.rb
@@ -1,0 +1,7 @@
+class NotifyChallengeCompletionJob < ApplicationJob
+  queue_as :notify_challenge_completion_job
+
+  def perform(challenge_id:)
+    ChallengeNotificationService.notify_challengers_of_completion(challenge_id: challenge_id)
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,4 +7,8 @@ class ApplicationMailer < ActionMailer::Base
   def _real_email_strategy?
     ENV['EMAIL_STRATEGY'] == 'real'
   end
+
+  def _url_for_env(path = '')
+    "#{ENV['APPLICATION_URL']}/#{path}"
+  end
 end

--- a/app/mailers/challenge_result_mailer.rb
+++ b/app/mailers/challenge_result_mailer.rb
@@ -1,0 +1,11 @@
+class ChallengeResultMailer < ApplicationMailer
+  attr_reader :performance, :result_path
+
+  def completed_email(performance_id:, email:)
+    @performance = Performance.find(performance_id)
+    @result_path = _url_for_env
+
+    to = _real_email_strategy? ? email : ENV['MAINTAINER_EMAIL']
+    mail(to: to, subject: 'OSUMB Challenge Results')
+  end
+end

--- a/app/mailers/password_reset_mailer.rb
+++ b/app/mailers/password_reset_mailer.rb
@@ -1,22 +1,18 @@
 class PasswordResetMailer < ApplicationMailer
   def password_reset_email(user_buck_id:, password_reset_request_id:)
-    generate_mail(user_buck_id, password_reset_request_id, 'OSUMB Challenges Password Reset')
+    _generate_mail(user_buck_id, password_reset_request_id, 'OSUMB Challenges Password Reset')
   end
 
   def user_creation_email(user_buck_id:, password_reset_request_id:)
-    generate_mail(user_buck_id, password_reset_request_id, 'OSUMB Challenge App')
+    _generate_mail(user_buck_id, password_reset_request_id, 'OSUMB Challenge App')
   end
 
   private
 
-  def generate_mail(user_buck_id, password_reset_request_id, subject)
+  def _generate_mail(user_buck_id, password_reset_request_id, subject)
     @user = User.find(user_buck_id)
     email = _real_email_strategy? ? @user.email : ENV['MAINTAINER_EMAIL']
-    @reset_link = url_for_env(password_reset_request_id)
+    @reset_link = _url_for_env("password_reset_requests/#{password_reset_request_id}")
     mail(to: email, subject: subject)
-  end
-
-  def url_for_env(prr_id)
-    "#{ENV['APPLICATION_URL']}/password_reset_requests/#{prr_id}"
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -29,7 +29,7 @@ class Spot < ApplicationRecord
   end
 
   class << self
-    # rubocop:disable Metrics/MethodLength, Style/IndentationConsistency
+    # rubocop:disable Metrics/MethodLength, Layout/IndentationConsistency
     def valid_instrument_part_for_row(row, instrument, part)
       case row
       when Spot.rows[:a], Spot.rows[:x]
@@ -54,7 +54,7 @@ class Spot < ApplicationRecord
         valid_s_row_instrument_part(instrument, part)
       end
     end
-    # rubocop:enable Metrics/MethodLength, Style/IndentationConsistency
+    # rubocop:enable Metrics/MethodLength, Layout/IndentationConsistency
 
     def get_row_from_database_value(db_value)
       Spot.rows.find { |_key, value| db_value == value }.first

--- a/app/services/challenge_notification_service.rb
+++ b/app/services/challenge_notification_service.rb
@@ -7,16 +7,18 @@ class ChallengeNotificationService
 
       raise ChallengeNotDoneError unless challenge.done_stage?
 
-      challenge.users.each do |user|
-        EmailJob.perform_later(
-          klass: 'ChallengeResultMailer',
-          method: 'completed_email',
-          args: {
-            performance_id: challenge.performance_id,
-            email: user.email
-          }
-        )
-      end
+      challenge.users.each { |user| _email_user(challenge.performance_id, user) }
+    end
+
+    def _email_user(performance_id, user)
+      EmailJob.perform_later(
+        klass: 'ChallengeResultMailer',
+        method: 'completed_email',
+        args: {
+          performance_id: performance_id,
+          email: user.email
+        }
+      )
     end
   end
 end

--- a/app/services/challenge_notification_service.rb
+++ b/app/services/challenge_notification_service.rb
@@ -1,0 +1,22 @@
+class ChallengeNotificationService
+  ChallengeNotDoneError = Class.new(StandardError)
+
+  class << self
+    def notify_challengers_of_completion(challenge_id:)
+      challenge = Challenge.find(challenge_id)
+
+      raise ChallengeNotDoneError unless challenge.done_stage?
+
+      challenge.users.each do |user|
+        EmailJob.perform_later(
+          klass: 'ChallengeResultMailer',
+          method: 'completed_email',
+          args: {
+            performance_id: challenge.performance_id,
+            email: user.email
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/services/performance_service.rb
+++ b/app/services/performance_service.rb
@@ -10,7 +10,7 @@ class PerformanceService
     )
   end
 
-  def self.update(id:, name:, date:, window_open:, window_close:, client_timezone:) # rubocop:disable Metrics/ParameterLists, Metric/LineLength
+  def self.update(id:, name:, date:, window_open:, window_close:, client_timezone:) # rubocop:disable Metrics/ParameterLists, Metrics/LineLength
     Time.use_zone(client_timezone) do
       p = Performance.find(id)
       p.update(name: name, date: date, window_close: window_close, window_open: window_open)

--- a/app/views/challenge_result_mailer/completed_email.html.erb
+++ b/app/views/challenge_result_mailer/completed_email.html.erb
@@ -1,0 +1,29 @@
+<table class="mui-body" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td class="mui-panel">
+      <center>
+        <!--[if mso]><table><tr><td class="mui-container-fixed"><![endif]-->
+        <div class="mui-container">
+          <div class="mui--text-headline">
+            <span style="padding-right: 350px;">Hey there!</span>
+            <%= image_tag("script_ohio_scarlet.jpg", size: '128x80') %>
+          </div>
+          <br />
+          <div class="mui--text-body2">
+            The results for the <%= @performance.name %> are in! To view them click the button below:
+            <br />
+            <br />
+            <a href="<%= @result_path %>" class="mui-btn mui-btn--primary">View Results</a>
+            <br />
+          <br />
+          <div class="mui--text-title">
+            Thanks,
+            <br />
+            OSUMB IT Office
+          </div>
+        </div>
+        <!--[if mso]></td></tr></table><![endif]-->
+      </center>
+    </td>
+  </tr>
+</table>

--- a/spec/controllers/challenges_controller_spec.rb
+++ b/spec/controllers/challenges_controller_spec.rb
@@ -280,6 +280,18 @@ RSpec.describe ChallengesController do
         expect(flash[:message]).to eq('Successfully saved challenge!')
       end
 
+      it 'does not call the CheckOtherChallengesDoneJob' do
+        expect(CheckOtherChallengesDoneJob).not_to receive(:perform_later).and_call_original
+
+        request
+      end
+
+      it 'does not call the NotifyChallengeCompletionJob' do
+        expect(NotifyChallengeCompletionJob).not_to receive(:perform_later).and_call_original
+
+        request
+      end
+
       context 'but the user isn\'t an admin, director, or squad leader' do
         let!(:current_user) { create(:user) }
 
@@ -381,6 +393,12 @@ RSpec.describe ChallengesController do
 
         it 'calls the CheckOtherChallengesDoneJob' do
           expect(CheckOtherChallengesDoneJob).to receive(:perform_later).and_call_original
+
+          put :update, params: params
+        end
+
+        it 'calls the NotifyChallengeCompletionJob' do
+          expect(NotifyChallengeCompletionJob).to receive(:perform_later).and_call_original
 
           put :update, params: params
         end

--- a/spec/mailers/previews/challenge_list_preview.rb
+++ b/spec/mailers/previews/challenge_list_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3001/rails/mailers/challenge_success_mailer
+# Preview all emails at http://localhost:3000/rails/mailers/challenge_success_mailer
 class ChallengeListPreview < ActionMailer::Preview
   def challenge_list_email
     builder = Challenge::ListBuilder.new(Performance.first)

--- a/spec/mailers/previews/challenge_result_mailer_preview.rb
+++ b/spec/mailers/previews/challenge_result_mailer_preview.rb
@@ -1,0 +1,10 @@
+# Preview all emails at http://localhost:3000/rails/mailers/challenge_result_mailer
+
+class ChallengeResultMailerPreview < ActionMailer::Preview
+  def completed_email
+    ChallengeResultMailer.completed_email(
+      performance_id: Performance.first.id,
+      email: User.first.email
+    )
+  end
+end

--- a/spec/mailers/previews/challenge_success_mailer_preview.rb
+++ b/spec/mailers/previews/challenge_success_mailer_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3001/rails/mailers/challenge_success_mailer
+# Preview all emails at http://localhost:3000/rails/mailers/challenge_success_mailer
 class ChallengeSuccessMailerPreview < ActionMailer::Preview
   def challenge_success_email_by_self
     ChallengeSuccessMailer.challenge_success_email(

--- a/spec/mailers/previews/new_password_mailer_preview.rb
+++ b/spec/mailers/previews/new_password_mailer_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3001/rails/mailers/new_password_email
+# Preview all emails at http://localhost:3000/rails/mailers/new_password_email
 class NewPasswordMailerPreview < ActionMailer::Preview
   def new_performance_email
     NewPerformanceMailer.new_performance_email(

--- a/spec/mailers/previews/password_reset_mailer_preview.rb
+++ b/spec/mailers/previews/password_reset_mailer_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3001/rails/mailers/password_reset_mailer
+# Preview all emails at http://localhost:3000/rails/mailers/password_reset_mailer
 class PasswordResetMailerPreview < ActionMailer::Preview
   def password_reset_email
     PasswordResetMailer.password_reset_email User.first, 5

--- a/spec/services/challenge_notification_service_spec.rb
+++ b/spec/services/challenge_notification_service_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe ChallengeNotificationService do
+  describe '.notify_challengers_of_completion' do
+    let(:challenge) { create(:normal_challenge, stage: stage) }
+    let(:stage) { :done }
+
+    context 'when called from the job' do
+      let(:job) { NotifyChallengeCompletionJob }
+
+      before { allow(described_class).to receive(:notify_challengers_of_completion).and_call_original }
+
+      it 'works' do
+        job.perform_now(challenge_id: challenge.id)
+
+        expect(described_class).to have_received(:notify_challengers_of_completion).with(challenge_id: challenge.id)
+      end
+    end
+
+    context 'when the challenge is not done' do
+      let(:stage) { :needs_comments }
+
+      it 'raises' do
+        expect do
+          described_class.notify_challengers_of_completion(challenge_id: challenge.id)
+        end.to raise_error(described_class::ChallengeNotDoneError)
+      end
+    end
+
+    context 'when the challenge is done' do
+      let(:stage) { :done }
+      let(:users) { challenge.users }
+
+      before { allow(EmailJob).to receive(:perform_later).and_call_original }
+
+      it 'emails the users of the challenge', :aggregate_failures do
+        described_class.notify_challengers_of_completion(challenge_id: challenge.id)
+
+        expect(users).not_to be_empty
+        users.each do |user|
+          expect(EmailJob).to have_received(:perform_later).with(
+            klass: 'ChallengeResultMailer',
+            method: 'completed_email',
+            args: {
+              performance_id: challenge.performance_id,
+              email: user.email
+            }
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a challenge has been submitted entirely (not just saved), this emails the users of the challenge to let them know they should check the results.

<img width="1792" alt="screen shot 2018-08-04 at 6 03 07 pm" src="https://user-images.githubusercontent.com/6563105/43680887-c95849d2-9812-11e8-9228-06c2109d1ef3.png">

Note: not sure why the scarlet ohio is missing. I followed the same conventions of the other emails.