### PR TITLE
Challenge bug

### DIFF
--- a/app/services/challenge_creation_service.rb
+++ b/app/services/challenge_creation_service.rb
@@ -1,4 +1,6 @@
 class ChallengeCreationService
+  ChallengeAlreadyFullError = Class.new(StandardError)
+
   def self.create_challenge(challenger:, performance:, spot:)
     new(challenger, performance, spot).perform
   end
@@ -15,6 +17,8 @@ class ChallengeCreationService
     users = _get_users_involved_in_challenge(@challenger, type, @spot, @performance)
     @challenge = _create_or_update(@performance, @spot, type, users)
     _result
+  rescue ChallengeAlreadyFullError
+    _error([I18n.t!("errors.challenges.create.challenge_already_full", spot: @spot.to_s)])
   end
 
   private
@@ -28,8 +32,13 @@ class ChallengeCreationService
     )
   end
 
+  def _error(errors = ["Error creating challenge"])
+    OpenStruct.new(success?: false, errors: errors)
+  end
+
   def _create_or_update(performance, spot, type, users)
     challenge = Challenge.find_by(performance: performance, spot: spot)
+    raise ChallengeAlreadyFullError if challenge&.full?
     if challenge.nil?
       _create(performance, spot, type, users)
     else

--- a/config/locales/en.errors.yml
+++ b/config/locales/en.errors.yml
@@ -2,5 +2,7 @@ en:
   errors:
     unexpected_value: "Unexpected %{variable_name} `%{value}`"
     challenges:
+      create:
+        challenge_already_full: "Spot %{spot} is fully challenged"
       update:
         invalid_update_type: "Invalid update type %{update_type}"


### PR DESCRIPTION
There's an issue where is two people try to challenge the same spot. The model validation worked, and an error returns from the service. However, a UserChallenge records gets created and associated the second challenger to the challenge anyway. This fix checks if the challenge is full before adding users 

The first commit is a failing test that shows the issue

The second commit fixes the test